### PR TITLE
Fix permission detection, overlay freeze, and settings UX

### DIFF
--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -87,6 +87,17 @@ final class AppCoordinator {
         )
         self.coordinator = breakCoordinator
         breakCoordinator.exercises = loadedExercises
+
+        overlayController.onSkip = { [weak breakCoordinator] in
+            breakCoordinator?.skipActiveBreak()
+        }
+        overlayController.onComplete = { [weak breakCoordinator] in
+            breakCoordinator?.completeActiveBreak()
+        }
+        overlayController.onEscape = { [weak breakCoordinator] in
+            breakCoordinator?.escapeActiveBreak()
+        }
+
         breakCoordinator.start(with: schedules.filter(\.isEnabled), preferences: preferences)
 
         eventListenerTask = Task {
@@ -101,6 +112,9 @@ final class AppCoordinator {
         eventListenerTask = nil
         coordinator?.stop()
         coordinator = nil
+        overlayController.onSkip = nil
+        overlayController.onComplete = nil
+        overlayController.onEscape = nil
     }
 
     private func restartCoordinator() {

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -59,17 +59,23 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     func dismissOverlay() {
+        guard isShowing else { return }
+
         if let observer = screenObserver {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
         }
         eventTapController?.stop()
         eventTapController = nil
-        for window in overlayWindows {
-            window.close()
-        }
+
+        let windows = overlayWindows
         overlayWindows.removeAll()
         isShowing = false
+
+        for window in windows {
+            window.contentView = nil
+            window.orderOut(nil)
+        }
     }
 
     private func startEventTap(preferences: AppPreferences) {

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -7,6 +7,7 @@ import Locking
 final class OverlayWindowController: LockPresenting, Observable {
     private var overlayWindows: [BreakOverlayWindow] = []
     private var eventTapController: EventTapController?
+    private var screenObserver: NSObjectProtocol?
     private(set) var isShowing: Bool = false
 
     private var currentLevel: DisciplineLevel?
@@ -58,6 +59,10 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     func dismissOverlay() {
+        if let observer = screenObserver {
+            NotificationCenter.default.removeObserver(observer)
+            screenObserver = nil
+        }
         eventTapController?.stop()
         eventTapController = nil
         for window in overlayWindows {
@@ -93,7 +98,7 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     private func observeScreenChanges() {
-        NotificationCenter.default.addObserver(
+        screenObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil, queue: .main
         ) { [weak self] _ in

--- a/StandLock/Views/BreakScreen/BreakContentView.swift
+++ b/StandLock/Views/BreakScreen/BreakContentView.swift
@@ -13,7 +13,6 @@ struct BreakContentView: View {
     @State private var remainingSeconds: TimeInterval
     @State private var skipDelayRemaining: TimeInterval
     @State private var typedPhrase: String = ""
-    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     init(
         level: DisciplineLevel, totalDuration: TimeInterval,
@@ -60,14 +59,17 @@ struct BreakContentView: View {
             }
             .padding(.horizontal, 40)
         }
-        .onReceive(timer) { _ in
-            guard remainingSeconds > 0 else { return }
-            remainingSeconds -= 1
-            if level == .firm && skipDelayRemaining > 0 {
-                skipDelayRemaining -= 1
-            }
-            if remainingSeconds <= 0 {
-                onComplete()
+        .task {
+            while !Task.isCancelled && remainingSeconds > 0 {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { break }
+                remainingSeconds -= 1
+                if level == .firm && skipDelayRemaining > 0 {
+                    skipDelayRemaining -= 1
+                }
+                if remainingSeconds <= 0 {
+                    onComplete()
+                }
             }
         }
     }

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -153,14 +153,30 @@ struct ScheduleFormView: View {
                     Text("Break every")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Stepper("\(breakIntervalMinutes) min", value: $breakIntervalMinutes, in: 5...180, step: 5)
+                    HStack(spacing: 4) {
+                        TextField("", value: $breakIntervalMinutes, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 50)
+                        Stepper("", value: $breakIntervalMinutes, in: 1...180, step: 5)
+                            .labelsHidden()
+                        Text("min")
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Break duration")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Stepper("\(breakDurationMinutes) min", value: $breakDurationMinutes, in: 1...60)
+                    HStack(spacing: 4) {
+                        TextField("", value: $breakDurationMinutes, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 50)
+                        Stepper("", value: $breakDurationMinutes, in: 1...60, step: 1)
+                            .labelsHidden()
+                        Text("min")
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -157,6 +157,9 @@ struct ScheduleFormView: View {
                         TextField("", value: $breakIntervalMinutes, format: .number)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 50)
+                            .onChange(of: breakIntervalMinutes) { _, newValue in
+                                breakIntervalMinutes = max(1, min(180, newValue))
+                            }
                         Stepper("", value: $breakIntervalMinutes, in: 1...180, step: 5)
                             .labelsHidden()
                         Text("min")
@@ -172,6 +175,9 @@ struct ScheduleFormView: View {
                         TextField("", value: $breakDurationMinutes, format: .number)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 50)
+                            .onChange(of: breakDurationMinutes) { _, newValue in
+                                breakDurationMinutes = max(1, min(60, newValue))
+                            }
                         Stepper("", value: $breakDurationMinutes, in: 1...60, step: 1)
                             .labelsHidden()
                         Text("min")

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -17,6 +17,7 @@ public final class BreakCoordinator: BreakCoordinating {
     private var breakCountdownTimer: Task<Void, Never>?
     private var isPaused: Bool = false
     private var currentBreak: BreakEvent?
+    private var currentSchedule: Schedule?
     private var statistics: BreakStatistics = BreakStatistics()
     private var dailyBreakCounts: [UUID: Int] = [:]
     public var exercises: [Exercise] = []
@@ -52,6 +53,7 @@ public final class BreakCoordinator: BreakCoordinating {
         breakCountdownTimer = nil
         if locker.isShowing { locker.dismissOverlay() }
         currentBreak = nil
+        currentSchedule = nil
     }
 
     public func pause(for duration: TimeInterval) {
@@ -80,6 +82,43 @@ public final class BreakCoordinator: BreakCoordinating {
         statistics.currentStreak = 0
         eventContinuation.yield(.statisticsUpdated(statistics))
         scheduleNextBreak()
+    }
+
+    public func skipActiveBreak() {
+        breakCountdownTimer?.cancel()
+        breakCountdownTimer = nil
+        guard var event = currentBreak else { return }
+        event.outcome = .skipped
+        locker.dismissOverlay()
+        statistics.breaksSkipped += 1
+        statistics.currentStreak = 0
+        eventContinuation.yield(.breakSkipped(event))
+        eventContinuation.yield(.statisticsUpdated(statistics))
+        currentBreak = nil
+        currentSchedule = nil
+        scheduleNextBreak()
+    }
+
+    public func escapeActiveBreak() {
+        breakCountdownTimer?.cancel()
+        breakCountdownTimer = nil
+        guard var event = currentBreak else { return }
+        event.outcome = .escaped
+        locker.dismissOverlay()
+        statistics.breaksEscaped += 1
+        statistics.weeklyEscapeCount += 1
+        eventContinuation.yield(.breakEscaped(event))
+        eventContinuation.yield(.statisticsUpdated(statistics))
+        currentBreak = nil
+        currentSchedule = nil
+        scheduleNextBreak()
+    }
+
+    public func completeActiveBreak() {
+        breakCountdownTimer?.cancel()
+        breakCountdownTimer = nil
+        guard let event = currentBreak, let schedule = currentSchedule else { return }
+        completeBreak(event: event, schedule: schedule)
     }
 
     public func changeDisciplineLevel(_ level: DisciplineLevel) {
@@ -168,6 +207,7 @@ public final class BreakCoordinator: BreakCoordinating {
             level: effectiveLevel, scheduleId: schedule.id
         )
         currentBreak = breakEvent
+        currentSchedule = schedule
         dailyBreakCounts[schedule.id, default: 0] += 1
 
         eventContinuation.yield(.breakStarted(breakEvent))
@@ -221,6 +261,7 @@ public final class BreakCoordinator: BreakCoordinating {
         eventContinuation.yield(.breakCompleted(completed))
         eventContinuation.yield(.statisticsUpdated(statistics))
         currentBreak = nil
+        currentSchedule = nil
         scheduleNextBreak()
     }
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -309,6 +309,123 @@ struct BreakCoordinatorTests {
     }
 
     @Test @MainActor
+    func skipActiveBreakDismissesAndResetsStreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        var skippedEvents: [BreakEvent] = []
+        var lastStats: BreakStatistics?
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakSkipped(let e) = event { skippedEvents.append(e) }
+                if case .statisticsUpdated(let s) = event { lastStats = s }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+
+        coordinator.skipActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(locker.dismissOverlayCalled)
+        #expect(skippedEvents.count == 1)
+        if case .skipped = skippedEvents.first?.outcome {} else {
+            Issue.record("Expected outcome .skipped")
+        }
+        #expect(lastStats?.breaksSkipped == 1)
+        #expect(lastStats?.currentStreak == 0)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
+    @Test @MainActor
+    func escapeActiveBreakDismissesAndIncrementsEscapeCount() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        var escapedEvents: [BreakEvent] = []
+        var lastStats: BreakStatistics?
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakEscaped(let e) = event { escapedEvents.append(e) }
+                if case .statisticsUpdated(let s) = event { lastStats = s }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+
+        coordinator.escapeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(locker.dismissOverlayCalled)
+        #expect(escapedEvents.count == 1)
+        if case .escaped = escapedEvents.first?.outcome {} else {
+            Issue.record("Expected outcome .escaped")
+        }
+        #expect(lastStats?.breaksEscaped == 1)
+        #expect(lastStats?.weeklyEscapeCount == 1)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
+    @Test @MainActor
+    func completeActiveBreakDismissesAndIncrementsStreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        var completedEvents: [BreakEvent] = []
+        var lastStats: BreakStatistics?
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakCompleted(let e) = event { completedEvents.append(e) }
+                if case .statisticsUpdated(let s) = event { lastStats = s }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(locker.dismissOverlayCalled)
+        #expect(completedEvents.count == 1)
+        if case .completed = completedEvents.first?.outcome {} else {
+            Issue.record("Expected outcome .completed")
+        }
+        #expect(lastStats?.breaksCompleted == 1)
+        #expect(lastStats?.currentStreak == 1)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
+    @Test @MainActor
     func dailyBreakCapRespected() async {
         let scheduler = MockScheduler()
         scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)


### PR DESCRIPTION
## Summary

- **Permission detection:** Add `needsRestart` state, functional probe for input monitoring, transition detection, and restart flow for TCC-cached permissions
- **Build config:** Add signing config, bundle ID (`com.yagizdokumaci.standlock`), and missing Info.plist keys
- **Overlay freeze fix:** Replace `NSWindow.close()` with `contentView=nil` + `orderOut(nil)` to prevent NSHostingView teardown deadlock/crash on break dismiss
- **Break coordination:** Wire overlay skip/complete/escape callbacks to BreakCoordinator, add `skipActiveBreak`/`escapeActiveBreak`/`completeActiveBreak` methods, fix resource leaks
- **Timer fix:** Replace `Timer.publish` with structured `.task` concurrency in BreakContentView countdown
- **Settings UX:** Replace stepper-only inputs with editable TextField + Stepper for break interval and duration

## Test plan

- [ ] Grant/revoke accessibility and input monitoring permissions — verify `needsRestart` state and restart flow work
- [ ] Trigger a break in gentle mode and press Skip — verify overlay dismisses without freeze or crash
- [ ] Trigger a break in firm mode, type escape phrase, skip — verify no freeze
- [ ] Let a break complete naturally — verify no freeze on auto-dismiss
- [ ] Plug/unplug external monitor during break — verify overlay re-creates correctly
- [ ] Open schedule settings, type exact values in break interval/duration fields — verify direct input works
- [ ] Use stepper arrows — verify increment/decrement by expected step values