### PR TITLE
fix(ui): overlay layout, permission gate, window focus, and docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yagiz Dogan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# StandLock
+
+A macOS menu bar app that reminds you to stand up and move. It sits quietly in your menu bar, tracks your schedules, and puts a full-screen overlay when it's time for a break. You pick how strict it should be: skip freely, type a phrase to dismiss, or lock your input entirely until the break is over.
+
+## Why
+
+Most break reminder apps show a notification you can swipe away in half a second. That doesn't work if you're deep in focus and keep ignoring it. StandLock takes a different approach: instead of asking nicely, it can actually block your screen. You choose the level of enforcement per schedule. Use Gentle mode during casual browsing and Strict mode during long coding sessions. The goal is to make skipping a break a conscious decision, not a reflex.
+
+## Features
+
+**Three Discipline Levels**
+
+| Level | Behavior |
+|-------|----------|
+| Gentle | Full-screen overlay with an immediate skip button |
+| Firm | Timed skip delay + type an escape phrase to dismiss |
+| Strict | Full input blocking, only an emergency key combo exits |
+
+**Smart Scheduling**
+- Multiple named schedules with independent settings
+- Time windows (e.g., 09:00–12:00, 13:00–17:00)
+- Day selection: weekdays, weekends, every day, or custom
+- Pomodoro-style repetition cycles (short/long break patterns)
+
+**Context Awareness**
+- Defers breaks during meetings (camera/microphone active)
+- Respects screen sharing sessions
+- Integrates with Calendar to skip during events
+- Detects idle time so you don't get a break after already being away
+- Honors macOS Focus modes
+
+**Break Experience**
+- Full-screen overlay with countdown timer
+- Exercise suggestions during breaks (stretches, water breaks, squats)
+- Streak and completion statistics in the menu bar
+
+## Requirements
+
+- macOS 14.0 or later
+- Accessibility permission (required for Strict mode input blocking)
+- Input Monitoring permission (recommended)
+- Calendar access (optional, for meeting detection)
+
+## Building from Source
+
+```bash
+git clone https://github.com/yagizdo/StandLock.git
+cd StandLock
+open StandLock.xcodeproj
+```
+
+Build and run the `StandLock` scheme in Xcode. The app lives in your menu bar.
+
+## Architecture
+
+StandLock is built with SwiftUI and AppKit, organized as a modular Swift Package:
+
+```
+StandLockKit/
+├── StandLockCore    # Shared models, protocols, and types
+├── Scheduling       # Schedule evaluation and repetition tracking
+├── Detection        # Camera, mic, screen sharing, calendar, idle, focus mode
+├── Coordination     # Break lifecycle orchestration
+└── Locking          # Event tap controller and escape detection
+```
+
+The main app target (`StandLock/`) contains the UI layer: menu bar popover, settings, onboarding, and the break overlay window.
+
+## License
+
+[MIT](LICENSE)

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -8,6 +8,8 @@ final class OverlayWindowController: LockPresenting, Observable {
     private var overlayWindows: [BreakOverlayWindow] = []
     private var eventTapController: EventTapController?
     private var screenObserver: NSObjectProtocol?
+    private var deactivationObserver: NSObjectProtocol?
+    private var focusTimer: Timer?
     private(set) var isShowing: Bool = false
 
     private var currentLevel: DisciplineLevel?
@@ -35,6 +37,8 @@ final class OverlayWindowController: LockPresenting, Observable {
         currentPreferences = preferences
         currentStatistics = statistics
 
+        NSApp.setActivationPolicy(.regular)
+
         for screen in NSScreen.screens {
             let window = BreakOverlayWindow(screen: screen)
             let contentView = BreakContentView(
@@ -55,6 +59,12 @@ final class OverlayWindowController: LockPresenting, Observable {
             startEventTap(preferences: preferences)
         }
 
+        forceFocus()
+
+        if level == .firm || level == .strict {
+            startFocusEnforcer()
+        }
+
         observeScreenChanges()
     }
 
@@ -65,6 +75,12 @@ final class OverlayWindowController: LockPresenting, Observable {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
         }
+        if let observer = deactivationObserver {
+            NotificationCenter.default.removeObserver(observer)
+            deactivationObserver = nil
+        }
+        focusTimer?.invalidate()
+        focusTimer = nil
         eventTapController?.stop()
         eventTapController = nil
 
@@ -76,6 +92,8 @@ final class OverlayWindowController: LockPresenting, Observable {
             window.contentView = nil
             window.orderOut(nil)
         }
+
+        NSApp.setActivationPolicy(.accessory)
     }
 
     private func startEventTap(preferences: AppPreferences) {
@@ -101,6 +119,19 @@ final class OverlayWindowController: LockPresenting, Observable {
     private func handleEscape() {
         dismissOverlay()
         onEscape?()
+    }
+
+    private func forceFocus() {
+        NSApp.activate()
+        overlayWindows.first?.orderFrontRegardless()
+        overlayWindows.first?.makeKeyAndOrderFront(nil)
+    }
+
+    private func startFocusEnforcer() {
+        focusTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
+            guard let self, self.isShowing else { return }
+            self.forceFocus()
+        }
     }
 
     private func observeScreenChanges() {

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -8,7 +8,6 @@ final class OverlayWindowController: LockPresenting, Observable {
     private var overlayWindows: [BreakOverlayWindow] = []
     private var eventTapController: EventTapController?
     private var screenObserver: NSObjectProtocol?
-    private var deactivationObserver: NSObjectProtocol?
     private var focusTimer: Timer?
     private(set) var isShowing: Bool = false
 
@@ -75,10 +74,6 @@ final class OverlayWindowController: LockPresenting, Observable {
             NotificationCenter.default.removeObserver(observer)
             screenObserver = nil
         }
-        if let observer = deactivationObserver {
-            NotificationCenter.default.removeObserver(observer)
-            deactivationObserver = nil
-        }
         focusTimer?.invalidate()
         focusTimer = nil
         eventTapController?.stop()
@@ -93,7 +88,13 @@ final class OverlayWindowController: LockPresenting, Observable {
             window.orderOut(nil)
         }
 
-        NSApp.setActivationPolicy(.accessory)
+        let hasOtherVisibleWindows = NSApp.windows.contains { window in
+            window.isVisible && !(window is BreakOverlayWindow)
+        }
+
+        if !hasOtherVisibleWindows {
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
 
     private func startEventTap(preferences: AppPreferences) {
@@ -129,8 +130,10 @@ final class OverlayWindowController: LockPresenting, Observable {
 
     private func startFocusEnforcer() {
         focusTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
-            guard let self, self.isShowing else { return }
-            self.forceFocus()
+            MainActor.assumeIsolated {
+                guard let self, self.isShowing else { return }
+                self.forceFocus()
+            }
         }
     }
 

--- a/StandLock/StandLockApp.swift
+++ b/StandLock/StandLockApp.swift
@@ -17,11 +17,13 @@ struct StandLockApp: App {
         Settings {
             SettingsView()
                 .environment(appCoordinator)
+                .onAppear { NSApp.activate() }
         }
 
         Window("Welcome to StandLock", id: "onboarding") {
             OnboardingView()
                 .environment(appCoordinator)
+                .onAppear { NSApp.activate() }
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 480, height: 520)

--- a/StandLock/Views/BreakScreen/BreakContentView.swift
+++ b/StandLock/Views/BreakScreen/BreakContentView.swift
@@ -33,7 +33,7 @@ struct BreakContentView: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(0.92)
+            Color.black.opacity(0.97)
                 .ignoresSafeArea()
 
             VStack(spacing: 28) {
@@ -46,11 +46,15 @@ struct BreakContentView: View {
                     totalDuration: totalDuration
                 )
 
-                if let exercise {
-                    ExerciseSuggestionView(exercise: exercise)
+                Group {
+                    if let exercise {
+                        ExerciseSuggestionView(exercise: exercise)
+                    }
                 }
+                .frame(minHeight: 60)
 
                 skipControls
+                    .frame(minHeight: 80)
 
                 Spacer()
 
@@ -121,32 +125,42 @@ struct BreakContentView: View {
                     .font(.callout)
                     .foregroundStyle(.white.opacity(0.5))
             } else if statistics.breaksSkipped < preferences.firmDailySkipLimit {
-                VStack(spacing: 8) {
-                    HStack(spacing: 8) {
-                        TextField("", text: $typedPhrase, prompt: Text(preferences.firmEscapePhrase).foregroundStyle(.white.opacity(0.3)))
-                            .textFieldStyle(.plain)
-                            .font(.callout)
-                            .foregroundStyle(.white)
-                            .padding(8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(.white.opacity(0.08))
-                            )
-                            .frame(maxWidth: 360)
+                VStack(spacing: 10) {
+                    Text(preferences.firmEscapePhrase)
+                        .font(.callout)
+                        .foregroundStyle(.white.opacity(0.4))
 
-                        if typedPhrase.lowercased() == preferences.firmEscapePhrase.lowercased() {
+                    TextField("", text: $typedPhrase)
+                        .textFieldStyle(.plain)
+                        .font(.callout)
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(.white.opacity(0.08))
+                        )
+                        .frame(maxWidth: 300)
+
+                    Group {
+                        if phraseMatches {
                             Button(action: onSkip) {
                                 Text("Skip")
                                     .font(.callout)
                                     .fontWeight(.medium)
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 8)
+                                    .frame(maxWidth: 300)
+                                    .padding(.vertical, 10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 8)
+                                            .fill(.white.opacity(0.15))
+                                    )
+                                    .contentShape(RoundedRectangle(cornerRadius: 8))
                             }
                             .buttonStyle(.plain)
-                            .background(Capsule().fill(.white.opacity(0.15)))
                             .foregroundStyle(.white)
                         }
                     }
+                    .frame(height: 40)
 
                     Text("Type the phrase above to skip")
                         .font(.caption)
@@ -208,6 +222,10 @@ struct BreakContentView: View {
     }
 
     // MARK: - Helpers
+
+    private var phraseMatches: Bool {
+        typedPhrase.lowercased() == preferences.firmEscapePhrase.lowercased()
+    }
 
     private var levelColor: Color {
         switch level {

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -22,6 +22,9 @@ struct MenuBarView: View {
         .task {
             if !coordinator.hasCompletedOnboarding {
                 openWindow(id: "onboarding")
+                DispatchQueue.main.async {
+                    NSApp.activate()
+                }
             }
         }
     }

--- a/StandLock/Views/Settings/DisciplineLevelPicker.swift
+++ b/StandLock/Views/Settings/DisciplineLevelPicker.swift
@@ -1,22 +1,47 @@
+import AppKit
 import SwiftUI
 import StandLockCore
 
 struct DisciplineLevelPicker: View {
     @Binding var selection: DisciplineLevel
+    @State private var checker = PermissionChecker()
+    @State private var showPermissionAlert = false
 
     var body: some View {
         HStack(spacing: 12) {
             ForEach(DisciplineLevel.allCases, id: \.self) { level in
-                LevelCard(level: level, isSelected: selection == level)
-                    .onTapGesture { selection = level }
+                LevelCard(
+                    level: level,
+                    isSelected: selection == level,
+                    isDisabled: level == .strict && !checker.accessibilityGranted
+                )
+                .onTapGesture {
+                    if level == .strict && !checker.accessibilityGranted {
+                        showPermissionAlert = true
+                    } else {
+                        selection = level
+                    }
+                }
             }
         }
+        .alert("Accessibility Permission Required", isPresented: $showPermissionAlert) {
+            Button("Open System Settings") {
+                for url in PermissionType.accessibility.settingsURLs {
+                    if NSWorkspace.shared.open(url) { break }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Strict mode requires Accessibility permission to block input during breaks.")
+        }
+        .task { await checker.pollContinuously() }
     }
 }
 
 private struct LevelCard: View {
     let level: DisciplineLevel
     let isSelected: Bool
+    var isDisabled: Bool = false
 
     var body: some View {
         VStack(spacing: 6) {
@@ -46,6 +71,7 @@ private struct LevelCard: View {
                 .stroke(isSelected ? accentColor : Color.secondary.opacity(0.3), lineWidth: isSelected ? 2 : 1)
         )
         .contentShape(RoundedRectangle(cornerRadius: 10))
+        .opacity(isDisabled ? 0.5 : 1)
     }
 
     private var iconName: String {

--- a/StandLock/Views/Settings/ScheduleEditorView.swift
+++ b/StandLock/Views/Settings/ScheduleEditorView.swift
@@ -113,6 +113,7 @@ private struct ScheduleRow: View {
                 set: { onToggle($0) }
             ))
             .toggleStyle(.switch)
+            .tint(.green)
             .labelsHidden()
 
             VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
## Summary
- Stabilize break overlay layout: persistent escape phrase hint, centered TextField, fixed-height containers for exercise and skip controls
- Add strict mode permission gate in DisciplineLevelPicker with accessibility alert
- Add green tint to schedule toggle
- Fix window ordering for onboarding and settings windows (NSApp.activate)
- Enforce overlay focus for firm/strict modes with periodic activation timer
- Darken overlay background opacity (0.92 → 0.97)
- Add README and MIT LICENSE

## Test plan
- [ ] Trigger a firm mode break, verify escape phrase is always visible above TextField
- [ ] Verify TextField stays centered and Skip button appears below when phrase matches
- [ ] Verify overlay steals focus from other apps in firm/strict mode
- [ ] Revoke accessibility permission, try to select Strict level, verify alert appears
- [ ] Toggle a schedule on/off, verify green tint
- [ ] Open Settings and onboarding from menu bar, verify they appear in front
- [ ] Build with no warnings, all 56 tests pass