### PR TITLE
Deferral UI fixes, palette update, and media pause during breaks

### DIFF
--- a/StandLock.xcodeproj/project.pbxproj
+++ b/StandLock.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		DABDEC6CA937B88679850A3E /* DetectionSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E6E6102A1900D1FAB2A856 /* DetectionSettingsView.swift */; };
 		E390B98931E7EE42E14FF2BD /* ActionArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A68046037D0CAAE70C0F88 /* ActionArea.swift */; };
 		ED1A168BD55576065212E8ED /* OverlayWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4462E8D161113596647BD19E /* OverlayWindowController.swift */; };
+		F1A2B3C4D5E6F7081920A1B2 /* MediaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7081920A1B3 /* MediaController.swift */; };
 		FBB74759FC16BB2E5F728128 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A85E4C082C8E3C5083ABAEB /* OnboardingView.swift */; };
 		FF4C7AAB3CFF56C574A3EAA2 /* BreakPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3B7E68FDF3C989BA50F367 /* BreakPalette.swift */; };
 /* End PBXBuildFile section */
@@ -58,6 +59,7 @@
 		434445F0717D4FC94E284CB8 /* ExerciseBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseBlock.swift; sourceTree = "<group>"; };
 		43B1BE95A60D5294C770AEDE /* StatsFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsFooter.swift; sourceTree = "<group>"; };
 		4462E8D161113596647BD19E /* OverlayWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowController.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7081920A1B3 /* MediaController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaController.swift; sourceTree = "<group>"; };
 		4CD0B4059D699DF8BDF99889 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		512EB234C46341A2816AAE12 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		52A2D12AD9D89928096A633C /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				A81F2ED91290AD26CB5B672E /* AppCoordinator.swift */,
+				F1A2B3C4D5E6F7081920A1B3 /* MediaController.swift */,
 				4462E8D161113596647BD19E /* OverlayWindowController.swift */,
 				FE0E2C708B760F809144B756 /* PermissionChecker.swift */,
 			);
@@ -323,6 +326,7 @@
 				09F7858EAC29160F684A60DD /* GeneralSettingsView.swift in Sources */,
 				726D144CA2B3B5AF4D4503AE /* LevelPill.swift in Sources */,
 				D751E70A3ADA8406061C5A90 /* ManuscriptBreakView.swift in Sources */,
+				F1A2B3C4D5E6F7081920A1B2 /* MediaController.swift in Sources */,
 				D4E5F6A7B8C9D0E1F2A3B4C6 /* MenuBarIcon.swift in Sources */,
 				1CCAA6FDBBB854DCBC1968EA /* MenuBarView.swift in Sources */,
 				FBB74759FC16BB2E5F728128 /* OnboardingView.swift in Sources */,

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -29,6 +29,7 @@ final class AppCoordinator {
     var currentBreakRemaining: TimeInterval = 0
     var currentLevel: DisciplineLevel = .gentle
     var todayStats: BreakStatistics = BreakStatistics()
+    var deferralReason: DeferralReason?
     var isPaused: Bool = false
     var pausedUntil: Date?
     var schedules: [Schedule] = []
@@ -163,11 +164,13 @@ final class AppCoordinator {
     private func handleEvent(_ event: CoordinatorEvent) {
         switch event {
         case .nextBreakScheduled(let date):
+            deferralReason = nil
             nextBreakTime = date
             breakScheduledAt = Date()
             recalculateProgress()
 
         case .breakStarted(let e):
+            deferralReason = nil
             isBreakActive = true
             currentBreakRemaining = e.duration
             currentLevel = e.level
@@ -178,8 +181,8 @@ final class AppCoordinator {
             currentBreakRemaining = 0
             breakProgress = 0
 
-        case .breakDeferred:
-            break
+        case .breakDeferred(let reason, _):
+            deferralReason = reason
 
         case .schedulePaused(let until):
             isPaused = true

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -97,6 +97,7 @@ final class AppCoordinator {
     func savePreferences() {
         guard let data = try? JSONEncoder().encode(preferences) else { return }
         UserDefaults.standard.set(data, forKey: "preferences")
+        coordinator?.updatePreferences(preferences)
     }
 
     func saveStatistics() {

--- a/StandLock/AppState/MediaController.swift
+++ b/StandLock/AppState/MediaController.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class MediaController {
+    private var didPause = false
+    private let sendCommand: (@convention(c) (UInt32, AnyObject?) -> Bool)?
+
+    init() {
+        guard let handle = dlopen(
+            "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote",
+            RTLD_NOW
+        ), let sym = dlsym(handle, "MRMediaRemoteSendCommand") else {
+            self.sendCommand = nil
+            return
+        }
+        self.sendCommand = unsafeBitCast(
+            sym, to: (@convention(c) (UInt32, AnyObject?) -> Bool).self
+        )
+    }
+
+    func pause() {
+        guard let sendCommand else { return }
+        _ = sendCommand(1, nil)
+        didPause = true
+    }
+
+    func resumeIfPaused() {
+        defer { didPause = false }
+        guard didPause, let sendCommand else { return }
+        _ = sendCommand(0, nil)
+    }
+
+    func reset() {
+        didPause = false
+    }
+}

--- a/StandLock/AppState/MediaController.swift
+++ b/StandLock/AppState/MediaController.swift
@@ -1,10 +1,11 @@
 import Foundation
 
+@MainActor
 final class MediaController {
     private var didPause = false
     private let sendCommand: (@convention(c) (UInt32, AnyObject?) -> Bool)?
 
-    init() {
+    nonisolated init() {
         guard let handle = dlopen(
             "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote",
             RTLD_NOW

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -76,6 +76,7 @@ final class OverlayWindowController: LockPresenting, Observable {
 
     func dismissOverlay() {
         guard isShowing else { return }
+        endBreakMedia()
 
         if let observer = screenObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -115,19 +116,16 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     private func handleSkip() {
-        endBreakMedia()
         dismissOverlay()
         onSkip?()
     }
 
     private func handleComplete() {
-        endBreakMedia()
         dismissOverlay()
         onComplete?()
     }
 
     private func handleEscape() {
-        endBreakMedia()
         dismissOverlay()
         onEscape?()
     }

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -9,6 +9,7 @@ final class OverlayWindowController: LockPresenting, Observable {
     private var eventTapController: EventTapController?
     private var screenObserver: NSObjectProtocol?
     private var focusTimer: Timer?
+    private let mediaController = MediaController()
     private(set) var isShowing: Bool = false
 
     private var currentLevel: DisciplineLevel?
@@ -67,6 +68,10 @@ final class OverlayWindowController: LockPresenting, Observable {
         }
 
         observeScreenChanges()
+
+        if preferences.pauseMediaDuringBreak {
+            mediaController.pause()
+        }
     }
 
     func dismissOverlay() {
@@ -110,18 +115,29 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     private func handleSkip() {
+        endBreakMedia()
         dismissOverlay()
         onSkip?()
     }
 
     private func handleComplete() {
+        endBreakMedia()
         dismissOverlay()
         onComplete?()
     }
 
     private func handleEscape() {
+        endBreakMedia()
         dismissOverlay()
         onEscape?()
+    }
+
+    private func endBreakMedia() {
+        if currentPreferences?.resumeMediaAfterBreak == true {
+            mediaController.resumeIfPaused()
+        } else {
+            mediaController.reset()
+        }
     }
 
     private func forceFocus() {

--- a/StandLock/StandLockApp.swift
+++ b/StandLock/StandLockApp.swift
@@ -18,18 +18,6 @@ struct StandLockApp: App {
         Settings {
             SettingsView()
                 .environment(appCoordinator)
-                .onAppear {
-                    NSApp.setActivationPolicy(.regular)
-                    NSApp.activate()
-                }
-                .onDisappear {
-                    let hasVisibleWindows = NSApp.windows.contains { window in
-                        window.isVisible && !(window is NSPanel)
-                    }
-                    if !hasVisibleWindows {
-                        NSApp.setActivationPolicy(.accessory)
-                    }
-                }
         }
         .commands {
             CommandGroup(after: .appInfo) {

--- a/StandLock/Views/BreakScreen/BreakPalette.swift
+++ b/StandLock/Views/BreakScreen/BreakPalette.swift
@@ -18,21 +18,21 @@ struct BreakPalette {
     }
 
     static let gentle = BreakPalette(
-        paper: Color(hex: 0xE0F9E7),
-        paperEdge: Color(hex: 0xC6F1D3),
-        ink: Color(hex: 0x0F1F14),
-        inkSoft: Color(hex: 0x3B4D41),
-        inkFaint: Color(hex: 0x7D8A81),
-        accent: Color(hex: 0x00793D)
+        paper: Color(hex: 0xE7ECF1),
+        paperEdge: Color(hex: 0xD0D9E2),
+        ink: Color(hex: 0x141B24),
+        inkSoft: Color(hex: 0x3C4858),
+        inkFaint: Color(hex: 0x7B8896),
+        accent: Color(hex: 0x5B7D9E)
     )
 
     static let firm = BreakPalette(
-        paper: Color(hex: 0xFFEAE2),
-        paperEdge: Color(hex: 0xFFD7CA),
-        ink: Color(hex: 0x271511),
-        inkSoft: Color(hex: 0x57423D),
-        inkFaint: Color(hex: 0x92827E),
-        accent: Color(hex: 0xA33E25)
+        paper: Color(hex: 0xDDDCE9),
+        paperEdge: Color(hex: 0xC0BFCF),
+        ink: Color(hex: 0x181622),
+        inkSoft: Color(hex: 0x443F58),
+        inkFaint: Color(hex: 0x807B91),
+        accent: Color(hex: 0x6E6993)
     )
 
     static let strict = BreakPalette(

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -129,7 +129,6 @@ struct MenuBarView: View {
         VStack(alignment: .leading, spacing: 4) {
             Button("Settings...") {
                 openSettings()
-                NSApp.setActivationPolicy(.regular)
                 NSApp.activate()
             }
             Button("Quit StandLock") {

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -57,6 +57,15 @@ struct MenuBarView: View {
             }
             .font(.caption)
             .foregroundStyle(.secondary)
+        } else if let reason = coordinator.deferralReason {
+            VStack(alignment: .leading, spacing: 2) {
+                Label("Break waiting", systemImage: "pause.circle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                Text(reason.displayName)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         } else if let nextBreak = coordinator.nextBreakTime {
             Label {
                 Text("Next break \(nextBreak, style: .relative)")

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -67,6 +67,37 @@ struct DetectionSettingsView: View {
                 )
             }
 
+            Section("Media") {
+                Toggle(isOn: $coordinator.preferences.pauseMediaDuringBreak) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Pause Media")
+                            Text("Pause audio playback when a break starts")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "speaker.slash")
+                    }
+                }
+
+                if coordinator.preferences.pauseMediaDuringBreak {
+                    Toggle(isOn: $coordinator.preferences.resumeMediaAfterBreak) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Resume After Break")
+                                Text("Automatically resume playback when the break ends")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "speaker.wave.2")
+                        }
+                    }
+                    .padding(.leading, 24)
+                }
+            }
+
             Section("Idle Recognition") {
                 Toggle(isOn: $coordinator.preferences.idleDetectionEnabled) {
                     Label {

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -127,6 +127,10 @@ public final class BreakCoordinator: BreakCoordinating {
         }
     }
 
+    public func updatePreferences(_ preferences: AppPreferences) {
+        self.preferences = preferences
+    }
+
     // MARK: - Private
 
     private func scheduleNextBreak() {

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -15,6 +15,9 @@ public struct AppPreferences: Codable, Sendable, Equatable {
     public var focusModeDetection: DetectionBehavior
     public var idleDetectionEnabled: Bool
 
+    public var pauseMediaDuringBreak: Bool
+    public var resumeMediaAfterBreak: Bool
+
     public var resetIntervalOnSkip: Bool
 
     public init(
@@ -29,6 +32,8 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         screenSharingDetectionEnabled: Bool = true,
         focusModeDetection: DetectionBehavior = .deferBreak,
         idleDetectionEnabled: Bool = true,
+        pauseMediaDuringBreak: Bool = true,
+        resumeMediaAfterBreak: Bool = false,
         resetIntervalOnSkip: Bool = true
     ) {
         self.firmSkipDelay = firmSkipDelay
@@ -42,6 +47,8 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         self.screenSharingDetectionEnabled = screenSharingDetectionEnabled
         self.focusModeDetection = focusModeDetection
         self.idleDetectionEnabled = idleDetectionEnabled
+        self.pauseMediaDuringBreak = pauseMediaDuringBreak
+        self.resumeMediaAfterBreak = resumeMediaAfterBreak
         self.resetIntervalOnSkip = resetIntervalOnSkip
     }
 }

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -51,6 +51,35 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         self.resumeMediaAfterBreak = resumeMediaAfterBreak
         self.resetIntervalOnSkip = resetIntervalOnSkip
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case firmSkipDelay, firmEscapePhrase, firmDailySkipLimit
+        case strictEscapeHoldDuration
+        case cameraDetection, microphoneDetection
+        case calendarDetectionEnabled, calendarLookAheadMinutes
+        case screenSharingDetectionEnabled
+        case focusModeDetection, idleDetectionEnabled
+        case pauseMediaDuringBreak, resumeMediaAfterBreak
+        case resetIntervalOnSkip
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        firmSkipDelay = try c.decodeIfPresent(TimeInterval.self, forKey: .firmSkipDelay) ?? 10
+        firmEscapePhrase = try c.decodeIfPresent(String.self, forKey: .firmEscapePhrase) ?? "I choose to skip this break"
+        firmDailySkipLimit = try c.decodeIfPresent(Int.self, forKey: .firmDailySkipLimit) ?? 5
+        strictEscapeHoldDuration = try c.decodeIfPresent(TimeInterval.self, forKey: .strictEscapeHoldDuration) ?? 10
+        cameraDetection = try c.decodeIfPresent(DetectionBehavior.self, forKey: .cameraDetection) ?? .deferBreak
+        microphoneDetection = try c.decodeIfPresent(DetectionBehavior.self, forKey: .microphoneDetection) ?? .deferBreak
+        calendarDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .calendarDetectionEnabled) ?? true
+        calendarLookAheadMinutes = try c.decodeIfPresent(Int.self, forKey: .calendarLookAheadMinutes) ?? 5
+        screenSharingDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .screenSharingDetectionEnabled) ?? true
+        focusModeDetection = try c.decodeIfPresent(DetectionBehavior.self, forKey: .focusModeDetection) ?? .deferBreak
+        idleDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .idleDetectionEnabled) ?? true
+        pauseMediaDuringBreak = try c.decodeIfPresent(Bool.self, forKey: .pauseMediaDuringBreak) ?? true
+        resumeMediaAfterBreak = try c.decodeIfPresent(Bool.self, forKey: .resumeMediaAfterBreak) ?? false
+        resetIntervalOnSkip = try c.decodeIfPresent(Bool.self, forKey: .resetIntervalOnSkip) ?? true
+    }
 }
 
 public enum DetectionBehavior: String, Codable, Sendable, CaseIterable {

--- a/StandLockKit/Sources/StandLockCore/Models/BreakEvent.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/BreakEvent.swift
@@ -33,4 +33,14 @@ public enum DeferralReason: String, Sendable, Codable {
     case calendarEvent
     case screenSharing
     case focusMode
+
+    public var displayName: String {
+        switch self {
+        case .cameraActive: "Camera in use"
+        case .microphoneActive: "Microphone in use"
+        case .calendarEvent: "Calendar event active"
+        case .screenSharing: "Screen sharing active"
+        case .focusMode: "Focus mode active"
+        }
+    }
 }

--- a/StandLockKit/Sources/StandLockCore/Protocols/BreakCoordinating.swift
+++ b/StandLockKit/Sources/StandLockCore/Protocols/BreakCoordinating.swift
@@ -20,4 +20,5 @@ public protocol BreakCoordinating: Sendable {
     @MainActor func resume()
     @MainActor func skipNextBreak()
     @MainActor func changeDisciplineLevel(_ level: DisciplineLevel)
+    @MainActor func updatePreferences(_ preferences: AppPreferences)
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -26,6 +26,7 @@ final class MockLocker: LockPresenting, @unchecked Sendable {
     var dismissOverlayCalled = false
     var lastLevel: DisciplineLevel?
     var lastDuration: TimeInterval?
+    var lastPreferences: AppPreferences?
     var isShowing = false
 
     func showOverlay(level: DisciplineLevel, duration: TimeInterval,
@@ -34,6 +35,7 @@ final class MockLocker: LockPresenting, @unchecked Sendable {
         showOverlayCalled = true
         lastLevel = level
         lastDuration = duration
+        lastPreferences = preferences
         isShowing = true
     }
 
@@ -448,6 +450,8 @@ struct BreakCoordinatorTests {
         try? await Task.sleep(for: .milliseconds(300))
 
         #expect(locker.showOverlayCalled)
+        #expect(locker.lastPreferences?.firmSkipDelay == 30)
+        #expect(locker.lastPreferences?.pauseMediaDuringBreak == false)
         coordinator.stop()
     }
 

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -426,6 +426,32 @@ struct BreakCoordinatorTests {
     }
 
     @Test @MainActor
+    func updatePreferencesApplied() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(60)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule()
+        let initial = AppPreferences()
+        coordinator.start(with: [schedule], preferences: initial)
+
+        var updated = AppPreferences()
+        updated.firmSkipDelay = 30
+        updated.pauseMediaDuringBreak = false
+        coordinator.updatePreferences(updated)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        coordinator.stop()
+        coordinator.start(with: [schedule], preferences: updated)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
     func dailyBreakCapRespected() async {
         let scheduler = MockScheduler()
         scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -132,6 +132,8 @@ struct ScheduleModelTests {
             screenSharingDetectionEnabled: false,
             focusModeDetection: .ignore,
             idleDetectionEnabled: false,
+            pauseMediaDuringBreak: false,
+            resumeMediaAfterBreak: true,
             resetIntervalOnSkip: false
         )
         let data = try JSONEncoder().encode(prefs)
@@ -141,6 +143,31 @@ struct ScheduleModelTests {
         #expect(decoded.cameraDetection == .reduceToGentle)
         #expect(decoded.microphoneDetection == .ignore)
         #expect(!decoded.calendarDetectionEnabled)
+        #expect(!decoded.pauseMediaDuringBreak)
+        #expect(decoded.resumeMediaAfterBreak)
         #expect(!decoded.resetIntervalOnSkip)
+    }
+
+    @Test func appPreferencesBackwardCompatibility() throws {
+        let json = """
+        {
+            "firmSkipDelay": 20,
+            "firmEscapePhrase": "skip",
+            "firmDailySkipLimit": 3,
+            "strictEscapeHoldDuration": 10,
+            "cameraDetection": "deferBreak",
+            "microphoneDetection": "deferBreak",
+            "calendarDetectionEnabled": true,
+            "calendarLookAheadMinutes": 5,
+            "screenSharingDetectionEnabled": true,
+            "focusModeDetection": "deferBreak",
+            "idleDetectionEnabled": true,
+            "resetIntervalOnSkip": true
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppPreferences.self, from: json)
+        #expect(decoded.firmSkipDelay == 20)
+        #expect(decoded.pauseMediaDuringBreak == true)
+        #expect(decoded.resumeMediaAfterBreak == false)
     }
 }


### PR DESCRIPTION
## Summary
- Pause system media (Music, Spotify, browser audio) when a break overlay appears, with optional auto-resume after break ends
- Fix stale countdown showing in menu bar when break is deferred — now shows deferral reason instead
- Propagate preference changes to running break coordinator so settings take effect immediately
- Switch gentle and firm break palettes to London Sands tones
- Prevent Dock icon from appearing when opening settings window

## Test plan
- [ ] Play music, trigger a break — audio should pause when overlay appears
- [ ] Enable "Resume After Break" in Detection settings — audio should resume when break ends
- [ ] Disable "Pause Media" toggle — audio should continue during breaks
- [ ] Defer a break (e.g., camera active) — menu bar should show deferral reason, not stale countdown
- [ ] Change discipline level in settings while a schedule is running — new level should apply to next break
- [ ] Open settings — Dock icon should not appear