### PR TITLE
Add progressive friction escalation tiers

### DIFF
--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -17,6 +17,7 @@ final class OverlayWindowController: LockPresenting, Observable {
     private var currentExercise: Exercise?
     private var currentPreferences: AppPreferences?
     private var currentStatistics: BreakStatistics?
+    private var currentEscalationTier: Int = 0
 
     var onSkip: (() -> Void)?
     var onComplete: (() -> Void)?
@@ -27,7 +28,7 @@ final class OverlayWindowController: LockPresenting, Observable {
     func showOverlay(
         level: DisciplineLevel, duration: TimeInterval,
         exercise: Exercise?, preferences: AppPreferences,
-        statistics: BreakStatistics
+        statistics: BreakStatistics, escalationTier: Int = 0
     ) {
         dismissOverlay()
 
@@ -36,6 +37,7 @@ final class OverlayWindowController: LockPresenting, Observable {
         currentExercise = exercise
         currentPreferences = preferences
         currentStatistics = statistics
+        currentEscalationTier = escalationTier
 
         NSApp.setActivationPolicy(.regular)
 
@@ -46,7 +48,7 @@ final class OverlayWindowController: LockPresenting, Observable {
             let contentView = ManuscriptBreakView(
                 level: level, totalDuration: duration,
                 exercise: exercise, preferences: preferences,
-                statistics: statistics,
+                statistics: statistics, escalationTier: escalationTier,
                 onSkip: { [weak self] in self?.handleSkip() },
                 onComplete: { [weak self] in self?.handleComplete() }
             )
@@ -105,9 +107,19 @@ final class OverlayWindowController: LockPresenting, Observable {
         }
     }
 
+    private static func tierMultiplier(_ tier: Int) -> Double {
+        switch tier {
+        case 0: 1.0
+        case 1: 1.5
+        case 2: 2.0
+        default: 2.5
+        }
+    }
+
     private func startEventTap(preferences: AppPreferences) {
+        let effectiveHold = preferences.strictEscapeHoldDuration * Self.tierMultiplier(currentEscalationTier)
         eventTapController = EventTapController(
-            escapeHoldDuration: preferences.strictEscapeHoldDuration,
+            escapeHoldDuration: effectiveHold,
             onEscapeTriggered: { [weak self] in
                 Task { @MainActor in self?.handleEscape() }
             }
@@ -167,11 +179,12 @@ final class OverlayWindowController: LockPresenting, Observable {
               let level = currentLevel,
               let prefs = currentPreferences,
               let stats = currentStatistics else { return }
+        let tier = currentEscalationTier
         dismissOverlay()
         showOverlay(
             level: level, duration: currentDuration,
             exercise: currentExercise, preferences: prefs,
-            statistics: stats
+            statistics: stats, escalationTier: tier
         )
     }
 }

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -108,12 +108,7 @@ final class OverlayWindowController: LockPresenting, Observable {
     }
 
     private static func tierMultiplier(_ tier: Int) -> Double {
-        switch tier {
-        case 0: 1.0
-        case 1: 1.5
-        case 2: 2.0
-        default: 2.5
-        }
+        AppPreferences.tierMultiplier(for: tier)
     }
 
     private func startEventTap(preferences: AppPreferences) {

--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -49,10 +49,10 @@ private struct GentleActionView: View {
     var body: some View {
         Group {
             if escalationTier == 0 {
-                immediateSkipButton
+                skipButton(animated: false)
             } else if showSkipAction {
                 switch escalationTier {
-                case 1: delayedSkipButton
+                case 1: skipButton(animated: true)
                 case 2: holdToSkipButton
                 default: typeToSkipField
                 }
@@ -84,7 +84,7 @@ private struct GentleActionView: View {
             .animation(.default, value: countdown)
     }
 
-    private var immediateSkipButton: some View {
+    private func skipButton(animated: Bool) -> some View {
         Button(action: onDismiss) {
             VStack(spacing: 4) {
                 Text("Skip this break \u{2192}")
@@ -97,25 +97,7 @@ private struct GentleActionView: View {
             .fixedSize()
         }
         .buttonStyle(.plain)
-        .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
-            isPressed = pressing
-        }, perform: {})
-    }
-
-    private var delayedSkipButton: some View {
-        Button(action: onDismiss) {
-            VStack(spacing: 4) {
-                Text("Skip this break \u{2192}")
-                    .font(BreakTypography.label(size: 14, weight: .medium))
-                    .foregroundStyle(palette.ink.opacity(isPressed ? 0.7 : 1))
-                Rectangle()
-                    .fill(palette.ink.opacity(isPressed ? 0.7 : 1))
-                    .frame(height: 1)
-            }
-            .fixedSize()
-        }
-        .buttonStyle(.plain)
-        .transition(.opacity)
+        .transition(animated ? .opacity : .identity)
         .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
             isPressed = pressing
         }, perform: {})
@@ -234,12 +216,7 @@ private struct FirmActionView: View {
     }
 
     private var tierMultiplier: Double {
-        switch escalationTier {
-        case 0: 1.0
-        case 1: 1.5
-        case 2: 2.0
-        default: 2.5
-        }
+        AppPreferences.tierMultiplier(for: escalationTier)
     }
 
     private var effectiveDelay: Int {
@@ -348,13 +325,7 @@ private struct StrictActionView: View {
     let escalationTier: Int
 
     private var effectiveHoldDuration: TimeInterval {
-        let multiplier: Double = switch escalationTier {
-        case 0: 1.0
-        case 1: 1.5
-        case 2: 2.0
-        default: 2.5
-        }
-        return preferences.strictEscapeHoldDuration * multiplier
+        preferences.strictEscapeHoldDuration * AppPreferences.tierMultiplier(for: escalationTier)
     }
 
     var body: some View {

--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -6,17 +6,20 @@ struct ActionArea: View {
     let palette: BreakPalette
     let preferences: AppPreferences
     let statistics: BreakStatistics
+    let escalationTier: Int
     let onDismiss: () -> Void
 
     var body: some View {
         switch level {
         case .gentle:
-            GentleActionView(palette: palette, onDismiss: onDismiss)
+            GentleActionView(palette: palette, escalationTier: escalationTier, onDismiss: onDismiss)
         case .firm:
             FirmActionView(palette: palette, preferences: preferences,
-                          statistics: statistics, onDismiss: onDismiss)
+                          statistics: statistics, escalationTier: escalationTier,
+                          onDismiss: onDismiss)
         case .strict:
-            StrictActionView(palette: palette, preferences: preferences, statistics: statistics)
+            StrictActionView(palette: palette, preferences: preferences,
+                            statistics: statistics, escalationTier: escalationTier)
         }
     }
 }
@@ -25,11 +28,63 @@ struct ActionArea: View {
 
 private struct GentleActionView: View {
     let palette: BreakPalette
+    let escalationTier: Int
     let onDismiss: () -> Void
 
     @State private var isPressed = false
+    @State private var showSkipAction = false
+    @State private var holdProgress: CGFloat = 0
+    @State private var typedPhrase = ""
+    @State private var countdown: Int = 0
+    @FocusState private var isFieldFocused: Bool
+
+    private var skipDelay: Int {
+        switch escalationTier {
+        case 1: 5
+        case 2: 10
+        default: 15
+        }
+    }
 
     var body: some View {
+        Group {
+            if escalationTier == 0 {
+                immediateSkipButton
+            } else if showSkipAction {
+                switch escalationTier {
+                case 1: delayedSkipButton
+                case 2: holdToSkipButton
+                default: typeToSkipField
+                }
+            } else {
+                countdownLabel
+            }
+        }
+        .animation(.easeOut(duration: 0.3), value: showSkipAction)
+        .task {
+            guard escalationTier >= 1 else {
+                showSkipAction = true
+                return
+            }
+            countdown = skipDelay
+            while countdown > 0 {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                countdown -= 1
+            }
+            showSkipAction = true
+        }
+    }
+
+    private var countdownLabel: some View {
+        Text("Skip available in \(countdown)s")
+            .font(BreakTypography.label(size: 12))
+            .foregroundStyle(palette.inkFaint)
+            .contentTransition(.numericText())
+            .animation(.default, value: countdown)
+    }
+
+    private var immediateSkipButton: some View {
         Button(action: onDismiss) {
             VStack(spacing: 4) {
                 Text("Skip this break \u{2192}")
@@ -46,6 +101,105 @@ private struct GentleActionView: View {
             isPressed = pressing
         }, perform: {})
     }
+
+    private var delayedSkipButton: some View {
+        Button(action: onDismiss) {
+            VStack(spacing: 4) {
+                Text("Skip this break \u{2192}")
+                    .font(BreakTypography.label(size: 14, weight: .medium))
+                    .foregroundStyle(palette.ink.opacity(isPressed ? 0.7 : 1))
+                Rectangle()
+                    .fill(palette.ink.opacity(isPressed ? 0.7 : 1))
+                    .frame(height: 1)
+            }
+            .fixedSize()
+        }
+        .buttonStyle(.plain)
+        .transition(.opacity)
+        .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
+            isPressed = pressing
+        }, perform: {})
+    }
+
+    private var holdToSkipButton: some View {
+        VStack(spacing: 8) {
+            Text("Hold to skip")
+                .font(BreakTypography.label(size: 12))
+                .foregroundStyle(palette.inkFaint)
+
+            ZStack {
+                Circle()
+                    .stroke(palette.paperEdge, lineWidth: 3)
+                    .frame(width: 44, height: 44)
+                Circle()
+                    .trim(from: 0, to: holdProgress)
+                    .stroke(palette.ink, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .frame(width: 44, height: 44)
+                    .rotationEffect(.degrees(-90))
+                Image(systemName: "forward.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(palette.ink)
+            }
+            .onLongPressGesture(minimumDuration: 2) {
+                onDismiss()
+            } onPressingChanged: { pressing in
+                if pressing {
+                    withAnimation(.linear(duration: 2)) {
+                        holdProgress = 1
+                    }
+                } else {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        holdProgress = 0
+                    }
+                }
+            }
+        }
+        .transition(.opacity)
+    }
+
+    private var typeToSkipField: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 0) {
+                Text("Write ")
+                    .font(BreakTypography.label(size: 12))
+                    .tracking(0.15)
+                    .foregroundStyle(palette.inkFaint)
+                Text("\"skip\"")
+                    .font(BreakTypography.exerciseName(size: 12).italic())
+                    .foregroundStyle(palette.ink)
+                Text(" to dismiss")
+                    .font(BreakTypography.label(size: 12))
+                    .tracking(0.15)
+                    .foregroundStyle(palette.inkFaint)
+            }
+
+            TextField("", text: $typedPhrase)
+                .font(BreakTypography.exerciseName(size: 16))
+                .foregroundStyle(palette.ink)
+                .multilineTextAlignment(.center)
+                .textFieldStyle(.plain)
+                .focused($isFieldFocused)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .frame(width: 200, height: 38)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.black.opacity(0.04))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(palette.paperEdge, lineWidth: 1)
+                )
+                .onAppear { isFieldFocused = true }
+                .onChange(of: typedPhrase) { _, newValue in
+                    if newValue.trimmingCharacters(in: .whitespaces)
+                        .caseInsensitiveCompare("skip") == .orderedSame {
+                        onDismiss()
+                    }
+                }
+        }
+        .transition(.opacity)
+    }
 }
 
 // MARK: - Firm
@@ -54,39 +208,97 @@ private struct FirmActionView: View {
     let palette: BreakPalette
     let preferences: AppPreferences
     let statistics: BreakStatistics
+    let escalationTier: Int
     let onDismiss: () -> Void
 
     @State private var typedPhrase = ""
+    @State private var showSkipConfirmation = false
+    @State private var showPhraseField = false
+    @State private var countdown: Int = 0
     @FocusState private var isFieldFocused: Bool
 
     private var limitReached: Bool {
-        statistics.breaksSkipped >= preferences.firmDailySkipLimit
+        guard !preferences.firmEscalationEnabled else { return false }
+        return statistics.breaksSkipped >= preferences.firmDailySkipLimit
+    }
+
+    private var effectivePhrase: String {
+        escalationTier >= 3
+            ? preferences.firmEscapePhrase + " I really mean it"
+            : preferences.firmEscapePhrase
     }
 
     private var phraseMatches: Bool {
         typedPhrase.trimmingCharacters(in: .whitespaces)
-            .caseInsensitiveCompare(preferences.firmEscapePhrase) == .orderedSame
+            .caseInsensitiveCompare(effectivePhrase) == .orderedSame
+    }
+
+    private var tierMultiplier: Double {
+        switch escalationTier {
+        case 0: 1.0
+        case 1: 1.5
+        case 2: 2.0
+        default: 2.5
+        }
+    }
+
+    private var effectiveDelay: Int {
+        Int(preferences.firmSkipDelay * tierMultiplier)
     }
 
     var body: some View {
         if !limitReached && preferences.firmEscapePhrase
             .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            GentleActionView(palette: palette, onDismiss: onDismiss)
+            GentleActionView(palette: palette, escalationTier: 0, onDismiss: onDismiss)
         } else {
             VStack(spacing: 16) {
                 if limitReached {
                     Text("Daily skip limit reached")
                         .font(BreakTypography.label(size: 12, weight: .medium))
                         .foregroundStyle(palette.inkFaint)
-                } else {
+                } else if showPhraseField {
                     promptLine
                     phraseField
+                } else if countdown > 0 {
+                    Text("Skip available in \(countdown)s")
+                        .font(BreakTypography.label(size: 12))
+                        .foregroundStyle(palette.inkFaint)
+                        .contentTransition(.numericText())
+                        .animation(.default, value: countdown)
                 }
             }
-            .onChange(of: phraseMatches) { _, matches in
-                if matches { onDismiss() }
+            .animation(.easeOut(duration: 0.3), value: showPhraseField)
+            .task {
+                let total = effectiveDelay
+                if total > 0 {
+                    countdown = total
+                    while countdown > 0 {
+                        try? await Task.sleep(for: .seconds(1))
+                        guard !Task.isCancelled else { return }
+                        countdown -= 1
+                    }
+                }
+                showPhraseField = true
             }
-            .onAppear { isFieldFocused = true }
+            .onChange(of: phraseMatches) { _, matches in
+                if matches {
+                    if escalationTier >= 2 {
+                        showSkipConfirmation = true
+                    } else {
+                        onDismiss()
+                    }
+                }
+            }
+            .alert("Skip this break?", isPresented: $showSkipConfirmation) {
+                Button("Skip", role: .destructive) { onDismiss() }
+                Button("Cancel", role: .cancel) { typedPhrase = "" }
+            }
+            .onChange(of: showSkipConfirmation) { _, showing in
+                if !showing { isFieldFocused = true }
+            }
+            .onChange(of: showPhraseField) { _, showing in
+                if showing { isFieldFocused = true }
+            }
         }
     }
 
@@ -96,7 +308,7 @@ private struct FirmActionView: View {
                 .font(BreakTypography.label(size: 12))
                 .tracking(0.15)
                 .foregroundStyle(palette.inkFaint)
-            Text("\"\(preferences.firmEscapePhrase)\"")
+            Text("\"\(effectivePhrase)\"")
                 .font(BreakTypography.exerciseName(size: 12).italic())
                 .foregroundStyle(palette.ink)
             Text(" to dismiss")
@@ -133,6 +345,17 @@ private struct StrictActionView: View {
     let palette: BreakPalette
     let preferences: AppPreferences
     let statistics: BreakStatistics
+    let escalationTier: Int
+
+    private var effectiveHoldDuration: TimeInterval {
+        let multiplier: Double = switch escalationTier {
+        case 0: 1.0
+        case 1: 1.5
+        case 2: 2.0
+        default: 2.5
+        }
+        return preferences.strictEscapeHoldDuration * multiplier
+    }
 
     var body: some View {
         VStack(spacing: 12) {
@@ -143,7 +366,7 @@ private struct StrictActionView: View {
                 keycap("⌃")
                 keycap("⌥")
                 keycap("⌘")
-                Text("for \(Int(preferences.strictEscapeHoldDuration)) seconds to exit.")
+                Text("for \(Int(effectiveHoldDuration)) seconds to exit.")
                     .font(BreakTypography.label(size: 13))
                     .foregroundStyle(palette.inkSoft)
             }

--- a/StandLock/Views/BreakScreen/ManuscriptBreakView.swift
+++ b/StandLock/Views/BreakScreen/ManuscriptBreakView.swift
@@ -7,6 +7,7 @@ struct ManuscriptBreakView: View {
     let exercise: Exercise?
     let preferences: AppPreferences
     let statistics: BreakStatistics
+    let escalationTier: Int
     let onSkip: () -> Void
     let onComplete: () -> Void
 
@@ -16,12 +17,14 @@ struct ManuscriptBreakView: View {
 
     init(level: DisciplineLevel, totalDuration: TimeInterval, exercise: Exercise?,
          preferences: AppPreferences, statistics: BreakStatistics,
+         escalationTier: Int = 0,
          onSkip: @escaping () -> Void, onComplete: @escaping () -> Void) {
         self.level = level
         self.totalDuration = totalDuration
         self.exercise = exercise
         self.preferences = preferences
         self.statistics = statistics
+        self.escalationTier = escalationTier
         self.onSkip = onSkip
         self.onComplete = onComplete
         self._remainingSeconds = State(initialValue: totalDuration)
@@ -57,6 +60,7 @@ struct ManuscriptBreakView: View {
                         ActionArea(
                             level: level, palette: palette,
                             preferences: preferences, statistics: statistics,
+                            escalationTier: escalationTier,
                             onDismiss: onSkip
                         )
                     }

--- a/StandLock/Views/Onboarding/OnboardingView.swift
+++ b/StandLock/Views/Onboarding/OnboardingView.swift
@@ -20,7 +20,13 @@ struct OnboardingView: View {
                     }
                 default:
                     QuickSetupStepView(
-                        onCreateDefault: {
+                        onCreateDefault: { escalationEnabled in
+                            if escalationEnabled {
+                                appCoordinator.preferences.gentleEscalationEnabled = true
+                                appCoordinator.preferences.firmEscalationEnabled = true
+                                appCoordinator.preferences.strictEscalationEnabled = true
+                                appCoordinator.savePreferences()
+                            }
                             appCoordinator.createDefaultSchedule()
                             appCoordinator.completeOnboarding()
                             dismiss()

--- a/StandLock/Views/Onboarding/QuickSetupStepView.swift
+++ b/StandLock/Views/Onboarding/QuickSetupStepView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
 struct QuickSetupStepView: View {
-    var onCreateDefault: () -> Void
+    var onCreateDefault: (_ escalationEnabled: Bool) -> Void
     var onSkip: () -> Void
+
+    @State private var escalationEnabled = false
 
     var body: some View {
         VStack(spacing: 24) {
@@ -34,11 +36,22 @@ struct QuickSetupStepView: View {
             .padding(16)
             .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 10))
 
+            Toggle(isOn: $escalationEnabled) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Progressive friction")
+                        .font(.subheadline.weight(.medium))
+                    Text("Each time you skip, the next break is harder to dismiss")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 20)
+
             Spacer()
 
             VStack(spacing: 10) {
                 Button("Use Default Schedule") {
-                    onCreateDefault()
+                    onCreateDefault(escalationEnabled)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -126,7 +126,12 @@ struct DetectionSettingsView: View {
             } header: {
                 Text("Progressive Friction")
             } footer: {
-                Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
+                    if coordinator.preferences.firmEscalationEnabled {
+                        Text("Firm escalation is active — daily skip limit is replaced by escalating friction.")
+                    }
+                }
             }
         }
         .formStyle(.grouped)

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -112,6 +112,22 @@ struct DetectionSettingsView: View {
                     }
                 }
             }
+
+            Section {
+                Toggle(isOn: $coordinator.preferences.gentleEscalationEnabled) {
+                    Text("Gentle")
+                }
+                Toggle(isOn: $coordinator.preferences.firmEscalationEnabled) {
+                    Text("Firm")
+                }
+                Toggle(isOn: $coordinator.preferences.strictEscalationEnabled) {
+                    Text("Strict")
+                }
+            } header: {
+                Text("Progressive Friction")
+            } footer: {
+                Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
+            }
         }
         .formStyle(.grouped)
         .onChange(of: coordinator.preferences) { _, _ in

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -109,6 +109,9 @@ public final class BreakCoordinator: BreakCoordinating {
         breakCountdownTimer = nil
         guard var event = currentBreak else { return }
         event.outcome = .escaped
+        if let scheduleID = currentBreak?.scheduleId {
+            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 3)
+        }
         locker.dismissOverlay()
         statistics.breaksEscaped += 1
         statistics.weeklyEscapeCount += 1
@@ -191,6 +194,7 @@ public final class BreakCoordinator: BreakCoordinating {
                     repetitionTrackers[schedule.id] = tracker
                 }
                 dailyBreakCounts[schedule.id, default: 0] += 1
+                escalationTiers[schedule.id] = 0
                 eventContinuation.yield(.breakCompleted(idleEvent))
                 eventContinuation.yield(.statisticsUpdated(statistics))
                 scheduleNextBreak()

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -20,6 +20,7 @@ public final class BreakCoordinator: BreakCoordinating {
     private var currentSchedule: Schedule?
     private var statistics: BreakStatistics = BreakStatistics()
     private var dailyBreakCounts: [UUID: Int] = [:]
+    private var escalationTiers: [UUID: Int] = [:]
     public var exercises: [Exercise] = []
 
     private let eventContinuation: AsyncStream<CoordinatorEvent>.Continuation
@@ -54,6 +55,7 @@ public final class BreakCoordinator: BreakCoordinating {
         if locker.isShowing { locker.dismissOverlay() }
         currentBreak = nil
         currentSchedule = nil
+        escalationTiers.removeAll()
     }
 
     public func pause(for duration: TimeInterval) {
@@ -89,6 +91,9 @@ public final class BreakCoordinator: BreakCoordinating {
         breakCountdownTimer = nil
         guard var event = currentBreak else { return }
         event.outcome = .skipped
+        if let scheduleID = currentBreak?.scheduleId {
+            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 3)
+        }
         locker.dismissOverlay()
         statistics.breaksSkipped += 1
         statistics.currentStreak = 0
@@ -129,6 +134,13 @@ public final class BreakCoordinator: BreakCoordinating {
 
     public func updatePreferences(_ preferences: AppPreferences) {
         self.preferences = preferences
+    }
+
+    // MARK: - Escalation
+
+    private func currentTier(for scheduleID: UUID, level: DisciplineLevel) -> Int {
+        guard preferences.escalationEnabled(for: level) else { return 0 }
+        return min(escalationTiers[scheduleID, default: 0], 3)
     }
 
     // MARK: - Private
@@ -206,6 +218,7 @@ public final class BreakCoordinator: BreakCoordinating {
 
         let duration = currentBreakDuration(for: schedule)
         let exercise = exercises.randomElement()
+        let tier = currentTier(for: schedule.id, level: effectiveLevel)
         let breakEvent = BreakEvent(
             scheduledAt: Date(), duration: duration,
             level: effectiveLevel, scheduleId: schedule.id
@@ -217,7 +230,7 @@ public final class BreakCoordinator: BreakCoordinating {
         eventContinuation.yield(.breakStarted(breakEvent))
         locker.showOverlay(level: effectiveLevel, duration: duration,
                            exercise: exercise, preferences: preferences,
-                           statistics: statistics)
+                           statistics: statistics, escalationTier: tier)
         startBreakCountdown(event: breakEvent, duration: duration, schedule: schedule)
     }
 
@@ -255,6 +268,7 @@ public final class BreakCoordinator: BreakCoordinating {
     private func completeBreak(event: BreakEvent, schedule: Schedule) {
         var completed = event
         completed.outcome = .completed
+        escalationTiers[schedule.id] = 0
         locker.dismissOverlay()
         statistics.breaksCompleted += 1
         statistics.currentStreak += 1

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -20,6 +20,18 @@ public struct AppPreferences: Codable, Sendable, Equatable {
 
     public var resetIntervalOnSkip: Bool
 
+    public var gentleEscalationEnabled: Bool
+    public var firmEscalationEnabled: Bool
+    public var strictEscalationEnabled: Bool
+
+    public func escalationEnabled(for level: DisciplineLevel) -> Bool {
+        switch level {
+        case .gentle: gentleEscalationEnabled
+        case .firm: firmEscalationEnabled
+        case .strict: strictEscalationEnabled
+        }
+    }
+
     public init(
         firmSkipDelay: TimeInterval = 10,
         firmEscapePhrase: String = "I choose to skip this break",
@@ -34,7 +46,10 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         idleDetectionEnabled: Bool = true,
         pauseMediaDuringBreak: Bool = true,
         resumeMediaAfterBreak: Bool = false,
-        resetIntervalOnSkip: Bool = true
+        resetIntervalOnSkip: Bool = true,
+        gentleEscalationEnabled: Bool = false,
+        firmEscalationEnabled: Bool = false,
+        strictEscalationEnabled: Bool = false
     ) {
         self.firmSkipDelay = firmSkipDelay
         self.firmEscapePhrase = firmEscapePhrase
@@ -50,6 +65,9 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         self.pauseMediaDuringBreak = pauseMediaDuringBreak
         self.resumeMediaAfterBreak = resumeMediaAfterBreak
         self.resetIntervalOnSkip = resetIntervalOnSkip
+        self.gentleEscalationEnabled = gentleEscalationEnabled
+        self.firmEscalationEnabled = firmEscalationEnabled
+        self.strictEscalationEnabled = strictEscalationEnabled
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -61,6 +79,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         case focusModeDetection, idleDetectionEnabled
         case pauseMediaDuringBreak, resumeMediaAfterBreak
         case resetIntervalOnSkip
+        case gentleEscalationEnabled, firmEscalationEnabled, strictEscalationEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -79,6 +98,9 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         pauseMediaDuringBreak = try c.decodeIfPresent(Bool.self, forKey: .pauseMediaDuringBreak) ?? true
         resumeMediaAfterBreak = try c.decodeIfPresent(Bool.self, forKey: .resumeMediaAfterBreak) ?? false
         resetIntervalOnSkip = try c.decodeIfPresent(Bool.self, forKey: .resetIntervalOnSkip) ?? true
+        gentleEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .gentleEscalationEnabled) ?? false
+        firmEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .firmEscalationEnabled) ?? false
+        strictEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .strictEscalationEnabled) ?? false
     }
 }
 

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -24,6 +24,15 @@ public struct AppPreferences: Codable, Sendable, Equatable {
     public var firmEscalationEnabled: Bool
     public var strictEscalationEnabled: Bool
 
+    public static func tierMultiplier(for tier: Int) -> Double {
+        switch tier {
+        case 0: 1.0
+        case 1: 1.5
+        case 2: 2.0
+        default: 2.5
+        }
+    }
+
     public func escalationEnabled(for level: DisciplineLevel) -> Bool {
         switch level {
         case .gentle: gentleEscalationEnabled

--- a/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
+++ b/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public protocol LockPresenting: Sendable {
+    /// - Parameter escalationTier: Progressive friction tier (0-3). 0 = no escalation, 3 = maximum friction.
     @MainActor func showOverlay(level: DisciplineLevel, duration: TimeInterval,
                                 exercise: Exercise?, preferences: AppPreferences,
                                 statistics: BreakStatistics, escalationTier: Int)

--- a/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
+++ b/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol LockPresenting: Sendable {
     @MainActor func showOverlay(level: DisciplineLevel, duration: TimeInterval,
                                 exercise: Exercise?, preferences: AppPreferences,
-                                statistics: BreakStatistics)
+                                statistics: BreakStatistics, escalationTier: Int)
     @MainActor func dismissOverlay()
     @MainActor var isShowing: Bool { get }
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -8,9 +8,12 @@ import Foundation
 
 final class MockScheduler: SchedulingEngine, @unchecked Sendable {
     var nextBreakTimeToReturn: Date?
+    var nextBreakTimes: [UUID: Date] = [:]
     var breakDurationToReturn: TimeInterval = 300
 
-    func nextBreakTime(for schedule: Schedule, after date: Date) -> Date? { nextBreakTimeToReturn }
+    func nextBreakTime(for schedule: Schedule, after date: Date) -> Date? {
+        nextBreakTimes[schedule.id] ?? nextBreakTimeToReturn
+    }
     func breakDuration(for schedule: Schedule, breakIndex: Int) -> TimeInterval { breakDurationToReturn }
     func isWithinActiveWindow(_ schedule: Schedule, at date: Date) -> Bool { true }
 }
@@ -557,6 +560,34 @@ struct BreakCoordinatorTests {
     }
 
     @Test @MainActor
+    func escapeIncrementsEscalationTier() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(strictEscalationEnabled: true)
+        let schedule = makeSchedule(level: .strict, breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
+        coordinator.escapeActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 1)
+
+        coordinator.escapeActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 2)
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
     func tierPerSchedule() async {
         let scheduler = MockScheduler()
         let detector = MockDetector()
@@ -567,18 +598,19 @@ struct BreakCoordinatorTests {
         let scheduleA = makeSchedule(level: .gentle)
         let scheduleB = makeSchedule(level: .gentle)
 
-        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        scheduler.nextBreakTimes[scheduleA.id] = Date().addingTimeInterval(0.05)
+        scheduler.nextBreakTimes[scheduleB.id] = Date().addingTimeInterval(100)
         coordinator.start(with: [scheduleA, scheduleB], preferences: prefs)
         try? await Task.sleep(for: .milliseconds(300))
 
+        #expect(locker.lastEscalationTier == 0)
+
+        scheduler.nextBreakTimes[scheduleA.id] = Date().addingTimeInterval(100)
+        scheduler.nextBreakTimes[scheduleB.id] = Date().addingTimeInterval(0.05)
         coordinator.skipActiveBreak()
-        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
         try? await Task.sleep(for: .milliseconds(300))
 
-        // The second break could be for either schedule, but tier tracking is per-schedule
-        // so at least one schedule should still be at tier 0 when triggered
-        let tier = locker.lastEscalationTier
-        #expect(tier != nil)
+        #expect(locker.lastEscalationTier == 0)
 
         coordinator.stop()
     }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -27,15 +27,17 @@ final class MockLocker: LockPresenting, @unchecked Sendable {
     var lastLevel: DisciplineLevel?
     var lastDuration: TimeInterval?
     var lastPreferences: AppPreferences?
+    var lastEscalationTier: Int?
     var isShowing = false
 
     func showOverlay(level: DisciplineLevel, duration: TimeInterval,
                      exercise: Exercise?, preferences: AppPreferences,
-                     statistics: BreakStatistics) {
+                     statistics: BreakStatistics, escalationTier: Int) {
         showOverlayCalled = true
         lastLevel = level
         lastDuration = duration
         lastPreferences = preferences
+        lastEscalationTier = escalationTier
         isShowing = true
     }
 
@@ -452,6 +454,157 @@ struct BreakCoordinatorTests {
         #expect(locker.showOverlayCalled)
         #expect(locker.lastPreferences?.firmSkipDelay == 30)
         #expect(locker.lastPreferences?.pauseMediaDuringBreak == false)
+        coordinator.stop()
+    }
+
+    // MARK: - Escalation Tier Tests
+
+    @Test @MainActor
+    func tierIncrementsOnSkip() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let schedule = makeSchedule(level: .gentle)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 1)
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 2)
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 3)
+
+        // Cap at 3
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 3)
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func tierResetsOnCompletion() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let schedule = makeSchedule(level: .gentle, breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 2)
+
+        coordinator.completeActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func tierZeroWhenDisabled() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(gentleEscalationEnabled: false)
+        let schedule = makeSchedule(level: .gentle)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func tierPerSchedule() async {
+        let scheduler = MockScheduler()
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let scheduleA = makeSchedule(level: .gentle)
+        let scheduleB = makeSchedule(level: .gentle)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        coordinator.start(with: [scheduleA, scheduleB], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        // The second break could be for either schedule, but tier tracking is per-schedule
+        // so at least one schedule should still be at tier 0 when triggered
+        let tier = locker.lastEscalationTier
+        #expect(tier != nil)
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func tierResetsOnStop() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let schedule = makeSchedule(level: .gentle)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        coordinator.skipActiveBreak()
+        coordinator.stop()
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 0)
+
         coordinator.stop()
     }
 

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -169,5 +169,21 @@ struct ScheduleModelTests {
         #expect(decoded.firmSkipDelay == 20)
         #expect(decoded.pauseMediaDuringBreak == true)
         #expect(decoded.resumeMediaAfterBreak == false)
+        #expect(decoded.gentleEscalationEnabled == false)
+        #expect(decoded.firmEscalationEnabled == false)
+        #expect(decoded.strictEscalationEnabled == false)
+    }
+
+    @Test func escalationPreferencesRoundTrip() throws {
+        let prefs = AppPreferences(
+            gentleEscalationEnabled: true,
+            firmEscalationEnabled: true,
+            strictEscalationEnabled: false
+        )
+        let data = try JSONEncoder().encode(prefs)
+        let decoded = try JSONDecoder().decode(AppPreferences.self, from: data)
+        #expect(decoded.gentleEscalationEnabled == true)
+        #expect(decoded.firmEscalationEnabled == true)
+        #expect(decoded.strictEscalationEnabled == false)
     }
 }


### PR DESCRIPTION
## Summary

Adds a progressive friction system that makes each subsequent break harder to dismiss when the user skips. Escalation tiers (0–3) track consecutive skips per schedule and reset when a break is completed. Each tier increases skip delay multipliers, hold durations, and introduces additional friction UI (countdown gates, hold-to-skip circles, type-to-dismiss fields, confirmation dialogs).

- **Modified:** `AppPreferences` — three per-level escalation toggles with `decodeIfPresent` for backward compatibility
- **Modified:** `BreakCoordinator` — per-schedule tier tracking, increment on skip, reset on completion/stop
- **Modified:** `LockPresenting` protocol — `escalationTier` parameter added to `showOverlay`
- **Modified:** `OverlayWindowController` — stores tier, applies multiplier to escape hold duration
- **Modified:** `ActionArea` — tier-aware skip UI for all three discipline levels
- **Modified:** `QuickSetupStepView` / `OnboardingView` — toggle to enable escalation during onboarding
- **Modified:** `DetectionSettingsView` — per-level escalation toggles in settings

### How it works

1. `BreakCoordinator` maintains `escalationTiers: [UUID: Int]` keyed by schedule ID.
2. On skip, the tier for that schedule increments (capped at 3). On break completion, it resets to 0. Stopping the coordinator clears all tiers.
3. The current tier is passed through `LockPresenting.showOverlay` → `ManuscriptBreakView` → `ActionArea`.
4. Each discipline level interprets the tier differently:
   - **Gentle**: T0 = instant skip, T1 = 5s countdown then button, T2 = 10s countdown then hold-to-skip, T3 = 15s countdown then type "skip"
   - **Firm**: delay scaled by 1.0×/1.5×/2.0×/2.5×, phrase extended at T3, confirmation dialog at T2+
   - **Strict**: escape hold duration multiplied by the same tier factors

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Per-schedule tracking | `[UUID: Int]` dictionary | Different schedules escalate independently |
| Cap at tier 3 | `min(tier + 1, 3)` | Prevents unbounded friction; 4 levels cover a meaningful range |
| Reset on completion only | Not on timer expiry | Rewards actually completing the break, not just waiting it out |
| Per-level enable flags | Three separate booleans | Users may want escalation for strict but not gentle |

## Test plan

- [ ] 6 new coordination tests: tier increments on skip, resets on completion, stays 0 when disabled, tracks per-schedule, resets on stop
- [ ] 2 new model tests: escalation flags survive encode/decode round-trip, backward-compatible decoding defaults to false
- [ ] Manual: skip a gentle break 4 times in a row and verify each tier's UI appears
- [ ] Manual: complete a break mid-escalation and verify tier resets to 0
- [ ] Manual: toggle escalation per level in Settings and verify behavior