### PR TITLE
refactor(escalation): replace boolean flags with EscalationLevel enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ secrets/
 progress.md
 
 # AI
+.superpowers/
 .claude/plans
 .claude/handovers
 .claude/reports

--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -200,7 +200,7 @@ private struct FirmActionView: View {
     @FocusState private var isFieldFocused: Bool
 
     private var limitReached: Bool {
-        guard !preferences.firmEscalationEnabled else { return false }
+        guard !preferences.escalationEnabled(for: .firm) else { return false }
         return statistics.breaksSkipped >= preferences.firmDailySkipLimit
     }
 

--- a/StandLock/Views/Onboarding/OnboardingView.swift
+++ b/StandLock/Views/Onboarding/OnboardingView.swift
@@ -22,9 +22,7 @@ struct OnboardingView: View {
                     QuickSetupStepView(
                         onCreateDefault: { escalationEnabled in
                             if escalationEnabled {
-                                appCoordinator.preferences.gentleEscalationEnabled = true
-                                appCoordinator.preferences.firmEscalationEnabled = true
-                                appCoordinator.preferences.strictEscalationEnabled = true
+                                appCoordinator.preferences.escalationLevel = .strict
                                 appCoordinator.savePreferences()
                             }
                             appCoordinator.createDefaultSchedule()

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -114,22 +114,37 @@ struct DetectionSettingsView: View {
             }
 
             Section {
-                Toggle(isOn: $coordinator.preferences.gentleEscalationEnabled) {
-                    Text("Gentle")
+                Toggle(isOn: Binding(
+                    get: { coordinator.preferences.escalationLevel != .off },
+                    set: { coordinator.preferences.escalationLevel = $0 ? .gentle : .off }
+                )) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Progressive Friction")
+                            Text("Escalate friction on repeated skips")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "chart.bar.fill")
+                    }
                 }
-                Toggle(isOn: $coordinator.preferences.firmEscalationEnabled) {
-                    Text("Firm")
+
+                if coordinator.preferences.escalationLevel != .off {
+                    Picker("Maximum Level", selection: $coordinator.preferences.escalationLevel) {
+                        Text("Gentle").tag(EscalationLevel.gentle)
+                        Text("Firm").tag(EscalationLevel.firm)
+                        Text("Strict").tag(EscalationLevel.strict)
+                    }
+                    .padding(.leading, 24)
                 }
-                Toggle(isOn: $coordinator.preferences.strictEscalationEnabled) {
-                    Text("Strict")
-                }
-            } header: {
-                Text("Progressive Friction")
             } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
-                    if coordinator.preferences.firmEscalationEnabled {
-                        Text("Firm escalation is active — daily skip limit is replaced by escalating friction.")
+                if coordinator.preferences.escalationLevel != .off {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
+                        if coordinator.preferences.escalationLevel >= .firm {
+                            Text("Firm escalation is active — daily skip limit is replaced by escalating friction.")
+                        }
                     }
                 }
             }

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -105,8 +105,11 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         pauseMediaDuringBreak = try c.decodeIfPresent(Bool.self, forKey: .pauseMediaDuringBreak) ?? true
         resumeMediaAfterBreak = try c.decodeIfPresent(Bool.self, forKey: .resumeMediaAfterBreak) ?? false
         resetIntervalOnSkip = try c.decodeIfPresent(Bool.self, forKey: .resetIntervalOnSkip) ?? true
-        if let level = try c.decodeIfPresent(EscalationLevel.self, forKey: .escalationLevel) {
+        if let rawLevel = try c.decodeIfPresent(Int.self, forKey: .escalationLevel),
+           let level = EscalationLevel(rawValue: rawLevel) {
             escalationLevel = level
+        } else if c.contains(.escalationLevel) {
+            escalationLevel = .off
         } else {
             let legacy = try decoder.container(keyedBy: LegacyKeys.self)
             let gentle = try legacy.decodeIfPresent(Bool.self, forKey: .gentleEscalationEnabled) ?? false

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -20,9 +20,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
 
     public var resetIntervalOnSkip: Bool
 
-    public var gentleEscalationEnabled: Bool
-    public var firmEscalationEnabled: Bool
-    public var strictEscalationEnabled: Bool
+    public var escalationLevel: EscalationLevel
 
     public static func tierMultiplier(for tier: Int) -> Double {
         switch tier {
@@ -35,9 +33,9 @@ public struct AppPreferences: Codable, Sendable, Equatable {
 
     public func escalationEnabled(for level: DisciplineLevel) -> Bool {
         switch level {
-        case .gentle: gentleEscalationEnabled
-        case .firm: firmEscalationEnabled
-        case .strict: strictEscalationEnabled
+        case .gentle: escalationLevel >= .gentle
+        case .firm: escalationLevel >= .firm
+        case .strict: escalationLevel >= .strict
         }
     }
 
@@ -56,9 +54,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         pauseMediaDuringBreak: Bool = true,
         resumeMediaAfterBreak: Bool = false,
         resetIntervalOnSkip: Bool = true,
-        gentleEscalationEnabled: Bool = false,
-        firmEscalationEnabled: Bool = false,
-        strictEscalationEnabled: Bool = false
+        escalationLevel: EscalationLevel = .off
     ) {
         self.firmSkipDelay = firmSkipDelay
         self.firmEscapePhrase = firmEscapePhrase
@@ -74,9 +70,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         self.pauseMediaDuringBreak = pauseMediaDuringBreak
         self.resumeMediaAfterBreak = resumeMediaAfterBreak
         self.resetIntervalOnSkip = resetIntervalOnSkip
-        self.gentleEscalationEnabled = gentleEscalationEnabled
-        self.firmEscalationEnabled = firmEscalationEnabled
-        self.strictEscalationEnabled = strictEscalationEnabled
+        self.escalationLevel = escalationLevel
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -88,6 +82,10 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         case focusModeDetection, idleDetectionEnabled
         case pauseMediaDuringBreak, resumeMediaAfterBreak
         case resetIntervalOnSkip
+        case escalationLevel
+    }
+
+    private enum LegacyKeys: String, CodingKey {
         case gentleEscalationEnabled, firmEscalationEnabled, strictEscalationEnabled
     }
 
@@ -107,9 +105,18 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         pauseMediaDuringBreak = try c.decodeIfPresent(Bool.self, forKey: .pauseMediaDuringBreak) ?? true
         resumeMediaAfterBreak = try c.decodeIfPresent(Bool.self, forKey: .resumeMediaAfterBreak) ?? false
         resetIntervalOnSkip = try c.decodeIfPresent(Bool.self, forKey: .resetIntervalOnSkip) ?? true
-        gentleEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .gentleEscalationEnabled) ?? false
-        firmEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .firmEscalationEnabled) ?? false
-        strictEscalationEnabled = try c.decodeIfPresent(Bool.self, forKey: .strictEscalationEnabled) ?? false
+        if let level = try c.decodeIfPresent(EscalationLevel.self, forKey: .escalationLevel) {
+            escalationLevel = level
+        } else {
+            let legacy = try decoder.container(keyedBy: LegacyKeys.self)
+            let gentle = try legacy.decodeIfPresent(Bool.self, forKey: .gentleEscalationEnabled) ?? false
+            let firm = try legacy.decodeIfPresent(Bool.self, forKey: .firmEscalationEnabled) ?? false
+            let strict = try legacy.decodeIfPresent(Bool.self, forKey: .strictEscalationEnabled) ?? false
+            if strict { escalationLevel = .strict }
+            else if firm { escalationLevel = .firm }
+            else if gentle { escalationLevel = .gentle }
+            else { escalationLevel = .off }
+        }
     }
 }
 

--- a/StandLockKit/Sources/StandLockCore/Models/EscalationLevel.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/EscalationLevel.swift
@@ -1,0 +1,19 @@
+public enum EscalationLevel: Int, Codable, Sendable, Comparable, CaseIterable {
+    case off = 0
+    case gentle = 1
+    case firm = 2
+    case strict = 3
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var displayName: String {
+        switch self {
+        case .off: "Off"
+        case .gentle: "Gentle"
+        case .firm: "Firm"
+        case .strict: "Strict"
+        }
+    }
+}

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -470,7 +470,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let prefs = AppPreferences(escalationLevel: .gentle)
         let schedule = makeSchedule(level: .gentle)
 
         coordinator.start(with: [schedule], preferences: prefs)
@@ -509,7 +509,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let prefs = AppPreferences(escalationLevel: .gentle)
         let schedule = makeSchedule(level: .gentle, breakDuration: 5)
 
         coordinator.start(with: [schedule], preferences: prefs)
@@ -540,7 +540,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(gentleEscalationEnabled: false)
+        let prefs = AppPreferences(escalationLevel: .off)
         let schedule = makeSchedule(level: .gentle)
 
         coordinator.start(with: [schedule], preferences: prefs)
@@ -567,7 +567,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(strictEscalationEnabled: true)
+        let prefs = AppPreferences(escalationLevel: .strict)
         let schedule = makeSchedule(level: .strict, breakDuration: 5)
 
         coordinator.start(with: [schedule], preferences: prefs)
@@ -594,7 +594,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let prefs = AppPreferences(escalationLevel: .gentle)
         let scheduleA = makeSchedule(level: .gentle)
         let scheduleB = makeSchedule(level: .gentle)
 
@@ -623,7 +623,7 @@ struct BreakCoordinatorTests {
         let locker = MockLocker()
 
         let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
-        let prefs = AppPreferences(gentleEscalationEnabled: true)
+        let prefs = AppPreferences(escalationLevel: .gentle)
         let schedule = makeSchedule(level: .gentle)
 
         coordinator.start(with: [schedule], preferences: prefs)

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -169,21 +169,25 @@ struct ScheduleModelTests {
         #expect(decoded.firmSkipDelay == 20)
         #expect(decoded.pauseMediaDuringBreak == true)
         #expect(decoded.resumeMediaAfterBreak == false)
-        #expect(decoded.gentleEscalationEnabled == false)
-        #expect(decoded.firmEscalationEnabled == false)
-        #expect(decoded.strictEscalationEnabled == false)
+        #expect(decoded.escalationLevel == .off)
     }
 
     @Test func escalationPreferencesRoundTrip() throws {
-        let prefs = AppPreferences(
-            gentleEscalationEnabled: true,
-            firmEscalationEnabled: true,
-            strictEscalationEnabled: false
-        )
+        let prefs = AppPreferences(escalationLevel: .firm)
         let data = try JSONEncoder().encode(prefs)
         let decoded = try JSONDecoder().decode(AppPreferences.self, from: data)
-        #expect(decoded.gentleEscalationEnabled == true)
-        #expect(decoded.firmEscalationEnabled == true)
-        #expect(decoded.strictEscalationEnabled == false)
+        #expect(decoded.escalationLevel == .firm)
+    }
+
+    @Test func escalationLegacyBoolMigration() throws {
+        let json = """
+        {
+            "gentleEscalationEnabled": true,
+            "firmEscalationEnabled": true,
+            "strictEscalationEnabled": false
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppPreferences.self, from: json)
+        #expect(decoded.escalationLevel == .firm)
     }
 }

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -190,4 +190,14 @@ struct ScheduleModelTests {
         let decoded = try JSONDecoder().decode(AppPreferences.self, from: json)
         #expect(decoded.escalationLevel == .firm)
     }
+
+    @Test func escalationUnrecognizedRawValueFallsBackToOff() throws {
+        let json = """
+        {
+            "escalationLevel": 99
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppPreferences.self, from: json)
+        #expect(decoded.escalationLevel == .off)
+    }
 }


### PR DESCRIPTION
## Summary

Replace three boolean escalation flags (`gentleEscalationEnabled`, `firmEscalationEnabled`, `strictEscalationEnabled`) with a single `EscalationLevel` enum. Simplifies the data model and settings UI while maintaining backward compatibility through legacy JSON migration.

- **New:** `EscalationLevel.swift` — `Comparable` enum with `.off`, `.gentle`, `.firm`, `.strict` cases
- **Modified:** `AppPreferences.swift` — single `escalationLevel` property replaces three booleans; custom decoder migrates legacy JSON
- **Modified:** `DetectionSettingsView.swift` — three toggles replaced with one toggle + level picker
- **Modified:** `OnboardingView.swift`, `ActionArea.swift` — updated call sites

## Test plan

- [ ] Existing unit tests pass (`escalationPreferencesRoundTrip`, `escalationLegacyBoolMigration`)
- [ ] Coordination tests pass for escalation tier behavior
- [ ] Settings UI shows toggle + picker instead of three separate toggles
- [ ] Users with existing preferences (boolean format) migrate correctly on decode