### PR TITLE
feat(menu): redesign menu bar dropdown

### DIFF
--- a/StandLock/AppDelegate.swift
+++ b/StandLock/AppDelegate.swift
@@ -2,12 +2,13 @@ import AppKit
 @preconcurrency import Sparkle
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    let updateObserver = UpdateObserver()
     let updaterController: SPUStandardUpdaterController
 
     override init() {
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: updateObserver,
             userDriverDelegate: nil
         )
         super.init()

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -22,6 +22,11 @@ private final class OnboardingWindowCloseDelegate: NSObject, NSWindowDelegate {
 
 @MainActor
 final class AppCoordinator: ObservableObject {
+    enum SettingsTab: Int, Hashable {
+        case general, schedules, detection, permissions, about
+    }
+
+    @Published var selectedSettingsTab: SettingsTab = .general
     @Published var nextBreakTime: Date?
     @Published private(set) var breakScheduledAt: Date?
     @Published var isBreakActive: Bool = false

--- a/StandLock/StandLockApp.swift
+++ b/StandLock/StandLockApp.swift
@@ -10,6 +10,7 @@ struct StandLockApp: App {
         MenuBarExtra {
             MenuBarView()
                 .environmentObject(appCoordinator)
+                .environmentObject(appDelegate.updateObserver)
         } label: {
             Image(nsImage: MenuBarIcon.make(progress: appCoordinator.breakProgress))
         }

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -3,17 +3,27 @@ import StandLockCore
 
 struct MenuBarView: View {
     @EnvironmentObject private var coordinator: AppCoordinator
+    @EnvironmentObject private var updateObserver: UpdateObserver
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            header
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 10) {
+                header
+                updateBanner
+                statusSection
+                statsBar
+            }
+            .padding(.horizontal, 4)
+            .padding(.bottom, 10)
+
             Divider()
-            statusSection
-            Divider()
-            statsBar
-            Divider()
+                .padding(.vertical, 6)
+
             QuickActionsView()
+
             Divider()
+                .padding(.vertical, 6)
+
             bottomActions
         }
         .padding(12)
@@ -122,33 +132,154 @@ struct MenuBarView: View {
         }
     }
 
+    // MARK: - Update Banner
+
+    @ViewBuilder
+    private var updateBanner: some View {
+        if updateObserver.updateAvailable {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 6, height: 6)
+                Text("v\(updateObserver.availableVersion ?? "?") available")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                Spacer()
+                Button("Update") {
+                    (NSApp.delegate as? AppDelegate)?.updaterController.updater.checkForUpdates()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+            .padding(10)
+            .background(.green.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.green.opacity(0.25)))
+        }
+    }
+
     // MARK: - Bottom Actions
 
     private var bottomActions: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 2) {
             if #available(macOS 14, *) {
-                SettingsButton()
+                SettingsRowButton(tab: nil, coordinator: coordinator)
+                SettingsRowButton(tab: .about, coordinator: coordinator)
             } else {
-                Button("Settings...") {
-                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-                    NSApp.activate(ignoringOtherApps: true)
+                Button {
+                    openSettingsLegacy()
+                } label: {
+                    settingsLabel
+                }
+                .buttonStyle(MenuBarRowStyle())
+
+                Button {
+                    coordinator.selectedSettingsTab = .about
+                    openSettingsLegacy()
+                } label: {
+                    aboutLabel
+                }
+                .buttonStyle(MenuBarRowStyle())
+            }
+
+            Button {
+                NSApp.terminate(nil)
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "power")
+                        .frame(width: 18)
+                        .foregroundStyle(.secondary)
+                    Text("Quit StandLock")
+                    Spacer()
+                    Text("\u{2318}Q")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
             }
-            Button("Quit StandLock") {
-                NSApp.terminate(nil)
-            }
+            .buttonStyle(MenuBarRowStyle())
         }
+    }
+
+    private var settingsLabel: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "gearshape")
+                .frame(width: 18)
+                .foregroundStyle(.secondary)
+            Text("Settings...")
+            Spacer()
+            Text("\u{2318},")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var aboutLabel: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle")
+                .frame(width: 18)
+                .foregroundStyle(.secondary)
+            Text("About StandLock")
+            Spacer()
+        }
+    }
+
+    private func openSettingsLegacy() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 }
 
 @available(macOS 14, *)
-private struct SettingsButton: View {
+private struct SettingsRowButton: View {
     @Environment(\.openSettings) private var openSettings
+    let tab: AppCoordinator.SettingsTab?
+    let coordinator: AppCoordinator
 
     var body: some View {
-        Button("Settings...") {
+        Button {
+            if let tab {
+                coordinator.selectedSettingsTab = tab
+            }
             openSettings()
             NSApp.activate(ignoringOtherApps: true)
+        } label: {
+            if tab == .about {
+                HStack(spacing: 8) {
+                    Image(systemName: "info.circle")
+                        .frame(width: 18)
+                        .foregroundStyle(.secondary)
+                    Text("About StandLock")
+                    Spacer()
+                }
+            } else {
+                HStack(spacing: 8) {
+                    Image(systemName: "gearshape")
+                        .frame(width: 18)
+                        .foregroundStyle(.secondary)
+                    Text("Settings...")
+                    Spacer()
+                    Text("\u{2318},")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
         }
+        .buttonStyle(MenuBarRowStyle())
+    }
+}
+
+struct MenuBarRowStyle: ButtonStyle {
+    @State private var isHovered = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .foregroundStyle(.primary)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+            )
+            .onHover { isHovered = $0 }
     }
 }

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -141,7 +141,7 @@ struct MenuBarView: View {
                 Circle()
                     .fill(.green)
                     .frame(width: 6, height: 6)
-                Text("v\(updateObserver.availableVersion ?? "?") available")
+                Text(updateObserver.availableVersion.map { "v\($0) available" } ?? "Update available")
                     .font(.caption)
                     .foregroundStyle(.green)
                 Spacer()
@@ -162,10 +162,11 @@ struct MenuBarView: View {
     private var bottomActions: some View {
         VStack(alignment: .leading, spacing: 2) {
             if #available(macOS 14, *) {
-                SettingsRowButton(tab: nil, coordinator: coordinator)
-                SettingsRowButton(tab: .about, coordinator: coordinator)
+                SettingsRowButton(tab: .general)
+                SettingsRowButton(tab: .about)
             } else {
                 Button {
+                    coordinator.selectedSettingsTab = .general
                     openSettingsLegacy()
                 } label: {
                     settingsLabel
@@ -199,68 +200,51 @@ struct MenuBarView: View {
         }
     }
 
-    private var settingsLabel: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "gearshape")
-                .frame(width: 18)
-                .foregroundStyle(.secondary)
-            Text("Settings...")
-            Spacer()
-            Text("\u{2318},")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-        }
-    }
-
-    private var aboutLabel: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "info.circle")
-                .frame(width: 18)
-                .foregroundStyle(.secondary)
-            Text("About StandLock")
-            Spacer()
-        }
-    }
-
     private func openSettingsLegacy() {
         NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 }
 
+private var settingsLabel: some View {
+    HStack(spacing: 8) {
+        Image(systemName: "gearshape")
+            .frame(width: 18)
+            .foregroundStyle(.secondary)
+        Text("Settings...")
+        Spacer()
+        Text("\u{2318},")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+    }
+}
+
+private var aboutLabel: some View {
+    HStack(spacing: 8) {
+        Image(systemName: "info.circle")
+            .frame(width: 18)
+            .foregroundStyle(.secondary)
+        Text("About StandLock")
+        Spacer()
+    }
+}
+
 @available(macOS 14, *)
 private struct SettingsRowButton: View {
     @Environment(\.openSettings) private var openSettings
-    let tab: AppCoordinator.SettingsTab?
-    let coordinator: AppCoordinator
+    @EnvironmentObject private var coordinator: AppCoordinator
+    let tab: AppCoordinator.SettingsTab
 
     var body: some View {
         Button {
-            if let tab {
-                coordinator.selectedSettingsTab = tab
-            }
+            coordinator.selectedSettingsTab = tab
             openSettings()
             NSApp.activate(ignoringOtherApps: true)
         } label: {
             if tab == .about {
-                HStack(spacing: 8) {
-                    Image(systemName: "info.circle")
-                        .frame(width: 18)
-                        .foregroundStyle(.secondary)
-                    Text("About StandLock")
-                    Spacer()
-                }
+                aboutLabel
             } else {
-                HStack(spacing: 8) {
-                    Image(systemName: "gearshape")
-                        .frame(width: 18)
-                        .foregroundStyle(.secondary)
-                    Text("Settings...")
-                    Spacer()
-                    Text("\u{2318},")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
+                settingsLabel
             }
         }
         .buttonStyle(MenuBarRowStyle())

--- a/StandLock/Views/MenuBar/QuickActionsView.swift
+++ b/StandLock/Views/MenuBar/QuickActionsView.swift
@@ -14,36 +14,60 @@ struct QuickActionsView: View {
                 Button {
                     coordinator.resumeSchedule()
                 } label: {
-                    Label("Resume Schedule", systemImage: "play.fill")
+                    HStack(spacing: 8) {
+                        Image(systemName: "play.fill")
+                            .frame(width: 18)
+                            .foregroundStyle(.secondary)
+                        Text("Resume Schedule")
+                        Spacer()
+                    }
                 }
+                .buttonStyle(MenuBarRowStyle())
             } else {
                 Button {
                     coordinator.skipNextBreak()
                 } label: {
-                    Label("Skip Next Break", systemImage: "forward.end")
+                    HStack(spacing: 8) {
+                        Image(systemName: "forward.end")
+                            .frame(width: 18)
+                            .foregroundStyle(.secondary)
+                        Text("Skip Next Break")
+                        Spacer()
+                    }
                 }
+                .buttonStyle(MenuBarRowStyle())
                 .disabled(coordinator.schedules.isEmpty || coordinator.isBreakActive)
 
-                Menu {
-                    Button("30 minutes") { coordinator.pauseSchedule(for: 30 * 60) }
-                    Button("1 hour") { coordinator.pauseSchedule(for: 60 * 60) }
-                    Button("2 hours") { coordinator.pauseSchedule(for: 2 * 60 * 60) }
+                Button {
+                    showPauseMenu()
                 } label: {
-                    Label("Pause Schedule", systemImage: "pause.circle")
+                    HStack(spacing: 8) {
+                        Image(systemName: "pause.circle")
+                            .frame(width: 18)
+                            .foregroundStyle(.secondary)
+                        Text("Pause Schedule")
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
+                .buttonStyle(MenuBarRowStyle())
                 .disabled(coordinator.schedules.isEmpty)
             }
 
             if let schedule = activeSchedule {
-                Divider()
                 scheduleInfo(schedule)
+                    .padding(.top, 4)
             }
         }
     }
 
     private func scheduleInfo(_ schedule: Schedule) -> some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 8) {
+            Text(levelIcon(schedule.disciplineLevel))
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 1) {
                 Text(schedule.name)
                     .font(.caption)
                     .fontWeight(.medium)
@@ -53,9 +77,32 @@ struct QuickActionsView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
-            Text(levelIcon(schedule.disciplineLevel))
-                .font(.caption)
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.primary.opacity(0.04))
+        )
+    }
+
+    private func showPauseMenu() {
+        let handler = PauseMenuHandler(coordinator: coordinator)
+        let menu = NSMenu()
+
+        let item30 = NSMenuItem(title: "30 minutes", action: #selector(PauseMenuHandler.pause30), keyEquivalent: "")
+        item30.target = handler
+        menu.addItem(item30)
+
+        let item60 = NSMenuItem(title: "1 hour", action: #selector(PauseMenuHandler.pause60), keyEquivalent: "")
+        item60.target = handler
+        menu.addItem(item60)
+
+        let item120 = NSMenuItem(title: "2 hours", action: #selector(PauseMenuHandler.pause120), keyEquivalent: "")
+        item120.target = handler
+        menu.addItem(item120)
+
+        menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
 
     private func levelIcon(_ level: DisciplineLevel) -> String {
@@ -65,4 +112,17 @@ struct QuickActionsView: View {
         case .strict: "🔴"
         }
     }
+}
+
+@MainActor
+private final class PauseMenuHandler: NSObject {
+    let coordinator: AppCoordinator
+
+    init(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    @objc func pause30() { coordinator.pauseSchedule(for: 30 * 60) }
+    @objc func pause60() { coordinator.pauseSchedule(for: 60 * 60) }
+    @objc func pause120() { coordinator.pauseSchedule(for: 2 * 60 * 60) }
 }

--- a/StandLock/Views/Settings/SettingsView.swift
+++ b/StandLock/Views/Settings/SettingsView.swift
@@ -1,22 +1,29 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject private var coordinator: AppCoordinator
+
     var body: some View {
-        TabView {
+        TabView(selection: $coordinator.selectedSettingsTab) {
             GeneralSettingsView()
                 .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(AppCoordinator.SettingsTab.general)
 
             ScheduleEditorView()
                 .tabItem { Label("Schedules", systemImage: "calendar.badge.clock") }
+                .tag(AppCoordinator.SettingsTab.schedules)
 
             DetectionSettingsView()
                 .tabItem { Label("Detection", systemImage: "eye") }
+                .tag(AppCoordinator.SettingsTab.detection)
 
             PermissionsView()
                 .tabItem { Label("Permissions", systemImage: "lock.shield") }
+                .tag(AppCoordinator.SettingsTab.permissions)
 
             AboutView()
                 .tabItem { Label("About", systemImage: "info.circle") }
+                .tag(AppCoordinator.SettingsTab.about)
         }
         .frame(width: 520, height: 480)
     }

--- a/StandLock/Views/Settings/SoftwareUpdate.swift
+++ b/StandLock/Views/Settings/SoftwareUpdate.swift
@@ -3,6 +3,26 @@ import Combine
 @preconcurrency import Sparkle
 
 @MainActor
+final class UpdateObserver: NSObject, ObservableObject, SPUUpdaterDelegate {
+    @Published var updateAvailable = false
+    @Published var availableVersion: String?
+
+    nonisolated override init() {
+        super.init()
+    }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        updateAvailable = true
+        availableVersion = item.displayVersionString
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        updateAvailable = false
+        availableVersion = nil
+    }
+}
+
+@MainActor
 final class CheckForUpdatesViewModel: ObservableObject {
     @Published var canCheckForUpdates = false
 


### PR DESCRIPTION
## Summary

- Redesign all menu bar action buttons (Settings, About, Quit, Skip, Pause, Resume) with rounded-row hover style via `MenuBarRowStyle` ButtonStyle
- Add inline Sparkle update banner below menu header that appears when a new version is detected
- Add "About StandLock" button that opens Settings window on the About tab via `SettingsTab` selection binding
- Replace SwiftUI `Menu` with `Button` + native `NSMenu.popUp` for pause duration picker to fix alignment issues with `.borderlessButton` intrinsic padding
- Remove dividers from header/status/stats section, group into a single visual block with consistent spacing

## Changes

- **SoftwareUpdate.swift**: New `UpdateObserver` class with `SPUUpdaterDelegate` conformance
- **AppDelegate.swift**: Wire `UpdateObserver` as `updaterDelegate` on `SPUStandardUpdaterController`
- **StandLockApp.swift**: Inject `updateObserver` as `environmentObject`
- **AppCoordinator.swift**: Add `SettingsTab` enum and `selectedSettingsTab` published property
- **SettingsView.swift**: Bind `TabView(selection:)` to coordinator's `selectedSettingsTab`
- **MenuBarView.swift**: Restyle bottom actions with icons/hover, add update banner, add `MenuBarRowStyle`, use `@Environment(\.openSettings)` on macOS 14+ with `sendAction` fallback
- **QuickActionsView.swift**: Apply `MenuBarRowStyle` to action buttons, replace `Menu` with `NSMenu.popUp`, restyle schedule info as rounded card

## Test plan

- [ ] All action buttons show rounded hover highlight on mouse over
- [ ] Menu looks identical to before when no update is available (banner hidden)
- [ ] "About StandLock" opens Settings window on About tab
- [ ] "Pause Schedule" button opens native dropdown with 30m/1h/2h options
- [ ] Update banner appears when Sparkle detects an available update
- [ ] Tapping "Update" in banner triggers Sparkle update dialog
- [ ] App builds and runs on macOS 13+ without regressions