### PR TITLE
Refresh settings UI with improved layout and escalation path

### DIFF
--- a/StandLock/Views/Settings/AboutView.swift
+++ b/StandLock/Views/Settings/AboutView.swift
@@ -34,23 +34,19 @@ struct AboutView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
-            Divider()
-                .padding(.horizontal, 80)
-
             VStack(alignment: .leading, spacing: 8) {
                 UpdaterSettingsView(updater: appDelegate.updaterController.updater)
                 CheckForUpdatesView(updater: appDelegate.updaterController.updater)
             }
             .padding(.horizontal, 40)
-
-            Divider()
-                .padding(.horizontal, 80)
+            .padding(12)
+            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
 
             VStack(spacing: 4) {
                 Text("Made by Yağız")
-                    .font(.callout)
+                    .font(.footnote)
                 Link("GitHub", destination: URL(string: "https://github.com/yagizdo/StandLock")!)
-                    .font(.callout)
+                    .font(.footnote)
             }
         }
         .padding(.top, 12)

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -66,7 +66,7 @@ struct DetectionSettingsView: View {
                 )
             }
 
-            Section("Media") {
+            Section("Media & Idle") {
                 Toggle(isOn: $coordinator.preferences.pauseMediaDuringBreak) {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
@@ -95,9 +95,7 @@ struct DetectionSettingsView: View {
                     }
                     .padding(.leading, 24)
                 }
-            }
 
-            Section("Idle Recognition") {
                 Toggle(isOn: $coordinator.preferences.idleDetectionEnabled) {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
@@ -120,7 +118,7 @@ struct DetectionSettingsView: View {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Progressive Friction")
-                            Text("Escalate friction on repeated skips")
+                            Text("Makes each skipped break harder to dismiss")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -130,21 +128,23 @@ struct DetectionSettingsView: View {
                 }
 
                 if coordinator.preferences.escalationLevel != .off {
-                    Picker("Maximum Level", selection: $coordinator.preferences.escalationLevel) {
+                    Picker("Level", selection: $coordinator.preferences.escalationLevel) {
                         Text("Gentle").tag(EscalationLevel.gentle)
                         Text("Firm").tag(EscalationLevel.firm)
                         Text("Strict").tag(EscalationLevel.strict)
                     }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
                     .padding(.leading, 24)
+
+                    escalationPathView
+                        .padding(.leading, 24)
                 }
+            } header: {
+                Text("Behavior")
             } footer: {
                 if coordinator.preferences.escalationLevel != .off {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Each skipped break makes the next skip harder. Resets when you complete a break.")
-                        if coordinator.preferences.escalationLevel >= .firm {
-                            Text("Firm escalation is active — daily skip limit is replaced by escalating friction.")
-                        }
-                    }
+                    Text("Taking a break resets the progression.")
                 }
             }
         }
@@ -152,6 +152,42 @@ struct DetectionSettingsView: View {
         .onChange(of: coordinator.preferences) { _ in
             coordinator.savePreferences()
         }
+    }
+
+    @ViewBuilder
+    private var escalationPathView: some View {
+        let selected = coordinator.preferences.escalationLevel
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Each skip advances to the next stage:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 6) {
+                stagePill("Delay", active: selected >= .gentle)
+                stageArrow(active: selected >= .firm)
+                stagePill("Phrase", active: selected >= .firm)
+                stageArrow(active: selected >= .strict)
+                stagePill("Key hold", active: selected >= .strict)
+            }
+        }
+    }
+
+    private func stagePill(_ label: String, active: Bool) -> some View {
+        Text(label)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(active ? Color.accentColor.opacity(0.15) : Color.secondary.opacity(0.08))
+            )
+            .foregroundStyle(active ? Color.accentColor : Color.secondary.opacity(0.3))
+    }
+
+    private func stageArrow(active: Bool) -> some View {
+        Image(systemName: "chevron.right")
+            .font(.system(size: 8, weight: .semibold))
+            .foregroundStyle(active ? .secondary : Color.secondary.opacity(0.3))
     }
 
     private func detectionRow(

--- a/StandLock/Views/Settings/GeneralSettingsView.swift
+++ b/StandLock/Views/Settings/GeneralSettingsView.swift
@@ -9,15 +9,22 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Launch at Startup", isOn: $launchAtStartup)
-                    .onChange(of: launchAtStartup) { newValue in
-                        guard !isUpdating else { return }
-                        setLaunchAtStartup(newValue)
+                Toggle(isOn: $launchAtStartup) {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Launch at Startup")
+                            Text("Open StandLock when you log in")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "laptopcomputer")
                     }
-
-                Text("Automatically open StandLock when you log in")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                }
+                .onChange(of: launchAtStartup) { newValue in
+                    guard !isUpdating else { return }
+                    setLaunchAtStartup(newValue)
+                }
 
                 if let errorMessage {
                     Text(errorMessage)

--- a/StandLock/Views/Settings/PermissionsView.swift
+++ b/StandLock/Views/Settings/PermissionsView.swift
@@ -6,12 +6,6 @@ struct PermissionsView: View {
     var body: some View {
         Form {
             Section {
-                Text("StandLock needs certain permissions to function properly. Grant the ones that match your usage.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-
-            Section("Recommended") {
                 PermissionRow(
                     title: "Input Monitoring",
                     description: "Detect keyboard activity for idle detection and escape combo. You'll need to enable it in System Settings.",
@@ -21,6 +15,15 @@ struct PermissionsView: View {
                     action: { checker.requestInputMonitoring() },
                     restartAction: { checker.relaunchApp() }
                 )
+            } header: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Grant permissions that match your usage.")
+                        .textCase(nil)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.bottom, 4)
+                    Text("Recommended")
+                }
             }
 
             Section("Optional") {

--- a/StandLock/Views/Settings/ScheduleEditorView.swift
+++ b/StandLock/Views/Settings/ScheduleEditorView.swift
@@ -46,7 +46,7 @@ struct ScheduleEditorView: View {
         VStack(spacing: 12) {
             Spacer()
             Image(systemName: "calendar.badge.plus")
-                .font(.system(size: 40))
+                .font(.system(size: 36))
                 .foregroundStyle(.secondary)
             Text("No Schedules")
                 .font(.headline)
@@ -242,19 +242,14 @@ private struct DeleteConfirmationView: View {
                 .buttonStyle(.bordered)
                 .keyboardShortcut(.cancelAction)
 
-                Button {
+                Button(role: .destructive) {
                     onDelete()
                 } label: {
                     Text("Delete")
-                        .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 6)
-                        .background(
-                            Color(red: 0.85, green: 0.33, blue: 0.33),
-                            in: RoundedRectangle(cornerRadius: 6)
-                        )
                 }
-                .buttonStyle(.plain)
+                .controlSize(.large)
             }
         }
         .padding(24)


### PR DESCRIPTION
## Summary

Refreshes the Settings UI for visual consistency and clarity. Sections are consolidated, the escalation picker gains a visual stage-path indicator, toggle rows use Label with icons and subtitles throughout, and platform-native controls replace manual color styling.

- **DetectionSettingsView** — Merge "Media" and "Idle Recognition" into one section; add segmented escalation picker with visual stage-path (Delay → Phrase → Key hold)
- **GeneralSettingsView** — Wrap "Launch at Startup" toggle in Label with icon and description subtitle
- **PermissionsView** — Move intro text into section header, merge with "Recommended" section
- **AboutView** — Replace dividers with rounded-rect card background for update section
- **ScheduleEditorView** — Use native `Button(role: .destructive)` instead of custom red styling

## Test plan

- [ ] Open Settings > Detection and verify escalation path visualization matches selected level
- [ ] Toggle escalation levels and confirm segmented picker and stage pills update correctly
- [ ] Open Settings > General and verify Launch at Startup shows icon + subtitle
- [ ] Open Settings > Permissions and verify intro text appears as section header
- [ ] Open Settings > About and verify update section has rounded card background
- [ ] Open Schedule editor, verify delete confirmation uses native destructive button