### PR TITLE
fix(overlay): enforce focus on all screens and block quit during breaks

### DIFF
--- a/StandLock/AppDelegate.swift
+++ b/StandLock/AppDelegate.swift
@@ -17,4 +17,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
     }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        let hasActiveOverlay = sender.windows.contains { $0 is BreakOverlayWindow && $0.isVisible }
+        return hasActiveOverlay ? .terminateCancel : .terminateNow
+    }
 }

--- a/StandLock/AppDelegate.swift
+++ b/StandLock/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if PermissionChecker.isRelaunching { return .terminateNow }
         let hasActiveOverlay = sender.windows.contains { $0 is BreakOverlayWindow && $0.isVisible }
         return hasActiveOverlay ? .terminateCancel : .terminateNow
     }

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -64,10 +64,7 @@ final class OverlayWindowController: LockPresenting {
         }
 
         forceFocus()
-
-        if level == .firm || level == .strict {
-            startFocusEnforcer()
-        }
+        startFocusEnforcer()
 
         observeScreenChanges()
 

--- a/StandLock/AppState/PermissionChecker.swift
+++ b/StandLock/AppState/PermissionChecker.swift
@@ -172,12 +172,15 @@ final class PermissionChecker: ObservableObject {
 
     @MainActor private static var shownRestartAlerts: Set<String> = []
 
+    private(set) static var isRelaunching = false
+
     func relaunchApp() {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         task.arguments = ["-n", Bundle.main.bundlePath]
         do {
             try task.run()
+            Self.isRelaunching = true
             NSApp.terminate(nil)
         } catch {
             let alert = NSAlert()

--- a/StandLock/Views/BreakScreen/BreakOverlayWindow.swift
+++ b/StandLock/Views/BreakScreen/BreakOverlayWindow.swift
@@ -7,8 +7,7 @@ final class BreakOverlayWindow: NSWindow {
             contentRect: screen.frame,
             styleMask: [.borderless, .fullSizeContentView],
             backing: .buffered,
-            defer: false,
-            screen: screen
+            defer: false
         )
         level = .screenSaver
         collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]

--- a/StandLock/Views/MenuBar/MenuBarView.swift
+++ b/StandLock/Views/MenuBar/MenuBarView.swift
@@ -197,6 +197,7 @@ struct MenuBarView: View {
                 }
             }
             .buttonStyle(MenuBarRowStyle())
+            .disabled(coordinator.isBreakActive)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix overlay not appearing on secondary screens by removing the `screen:` parameter from `BreakOverlayWindow` init — `screen.frame` global coordinates are sufficient for correct multi-monitor positioning
- Block app termination (Cmd+Q / menu Quit) while a break overlay is active via `applicationShouldTerminate`
- Disable the Quit button in the menu bar dropdown during active breaks
- Enable focus enforcement (0.3s re-raise timer) for all discipline levels, not just Firm/Strict — overlay staying on top is fundamental regardless of level

## Test plan
- [ ] Trigger a break with two monitors connected, verify overlay appears on both screens
- [ ] Try Cmd+Q and menu Quit during a break, verify app does not terminate
- [ ] Verify Quit button appears disabled in menu dropdown during break
- [ ] Verify Quit works normally when no break is active
- [ ] Test with Gentle, Firm, and Strict levels — overlay should stay on top in all three