### PR TITLE
feat(release): replace ZIP distribution with DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             -exportPath "$RUNNER_TEMP/export" \
             -exportOptionsPlist "$RUNNER_TEMP/export-options.plist"
 
-      # ── Sign & Notarize ──
+      # ── Sign ──
 
       - name: Fix Sparkle framework symlinks
         run: scripts/fix-sparkle-symlinks.sh
@@ -103,13 +103,22 @@ jobs:
       - name: Re-sign app and frameworks
         run: scripts/resign-app.sh
 
-      - name: Notarize and staple
-        run: scripts/notarize.sh
-
       # ── Package ──
 
-      - name: Create release ZIP and checksum
-        run: scripts/create-release-zip.sh
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Create release DMG
+        run: scripts/create-release-dmg.sh
+
+      - name: Notarize and staple DMG
+        run: scripts/notarize.sh
+
+      - name: Create DMG checksum
+        run: |
+          shasum -a 256 "StandLock-${VERSION}.dmg" > "StandLock-${VERSION}.dmg.sha256"
+          SHA256_VALUE=$(awk '{print $1}' "StandLock-${VERSION}.dmg.sha256")
+          echo "SHA256=${SHA256_VALUE}" >> "$GITHUB_ENV"
 
       - name: Generate Sparkle appcast
         env:
@@ -135,8 +144,8 @@ jobs:
           gh release create "v${VERSION}" \
             --title "StandLock v${VERSION}" \
             "${NOTES_ARGS[@]}" \
-            "StandLock-${VERSION}.zip" \
-            "StandLock-${VERSION}.zip.sha256" \
+            "StandLock-${VERSION}.dmg" \
+            "StandLock-${VERSION}.dmg.sha256" \
             appcast.xml
 
       - name: Update Homebrew cask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,15 @@ jobs:
       - name: Re-sign app and frameworks
         run: scripts/resign-app.sh
 
-      # ── Package ──
+      # ── Notarize & Package ──
+
+      - name: Notarize app bundle
+        run: |
+          ditto -c -k --keepParent --rsrc --sequesterRsrc \
+            "$RUNNER_TEMP/export/StandLock.app" "$RUNNER_TEMP/StandLock-notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/StandLock-notarize.zip" \
+            --keychain-profile "ci-notary" --wait
+          xcrun stapler staple "$RUNNER_TEMP/export/StandLock.app"
 
       - name: Install create-dmg
         run: brew install create-dmg

--- a/scripts/create-release-dmg.sh
+++ b/scripts/create-release-dmg.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+create-dmg \
+  --volname "StandLock" \
+  --window-pos 200 120 \
+  --window-size 660 400 \
+  --icon-size 80 \
+  --icon "StandLock.app" 180 170 \
+  --app-drop-link 480 170 \
+  --no-internet-enable \
+  --skip-jenkins \
+  --hdiutil-quiet \
+  "StandLock-${VERSION}.dmg" \
+  "$RUNNER_TEMP/export/StandLock.app"

--- a/scripts/create-release-zip.sh
+++ b/scripts/create-release-zip.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-ditto -c -k --keepParent --rsrc --sequesterRsrc \
-  "$RUNNER_TEMP/export/StandLock.app" "StandLock-${VERSION}.zip"
-shasum -a 256 "StandLock-${VERSION}.zip" > "StandLock-${VERSION}.zip.sha256"
-SHA256_VALUE=$(awk '{print $1}' "StandLock-${VERSION}.zip.sha256")
-echo "SHA256=${SHA256_VALUE}" >> "$GITHUB_ENV"

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -14,14 +14,14 @@ chmod +x "$SIGN_UPDATE"
 KEY_FILE="$RUNNER_TEMP/sparkle-key"
 echo "$SPARKLE_PRIVATE_KEY" > "$KEY_FILE"
 
-SIGN_OUTPUT=$("$SIGN_UPDATE" "StandLock-${VERSION}.zip" --ed-key-file "$KEY_FILE")
+SIGN_OUTPUT=$("$SIGN_UPDATE" "StandLock-${VERSION}.dmg" --ed-key-file "$KEY_FILE")
 ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
 if [ -z "$ED_SIGNATURE" ]; then
   echo "::error::sign_update did not produce an edSignature. Raw output:"
   echo "$SIGN_OUTPUT"
   exit 1
 fi
-FILE_LENGTH=$(stat -f%z "StandLock-${VERSION}.zip")
+FILE_LENGTH=$(stat -f%z "StandLock-${VERSION}.dmg")
 PUB_DATE=$(date "+%a, %d %b %Y %H:%M:%S %z")
 
 cat > appcast.xml <<APPCAST
@@ -35,7 +35,7 @@ cat > appcast.xml <<APPCAST
       <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
       <pubDate>${PUB_DATE}</pubDate>
-      <enclosure url="https://github.com/yagizdo/StandLock/releases/download/v${VERSION}/StandLock-${VERSION}.zip"
+      <enclosure url="https://github.com/yagizdo/StandLock/releases/download/v${VERSION}/StandLock-${VERSION}.dmg"
                  sparkle:edSignature="${ED_SIGNATURE}"
                  length="${FILE_LENGTH}"
                  type="application/octet-stream" />

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-APP="$RUNNER_TEMP/export/StandLock.app"
-
-ditto -c -k --keepParent --rsrc --sequesterRsrc \
-  "$APP" "$RUNNER_TEMP/StandLock-notarize.zip"
-xcrun notarytool submit "$RUNNER_TEMP/StandLock-notarize.zip" \
+xcrun notarytool submit "StandLock-${VERSION}.dmg" \
   --keychain-profile "ci-notary" --wait
 
-xcrun stapler staple "$APP"
-xattr -cr "$APP"
+xcrun stapler staple "StandLock-${VERSION}.dmg"

--- a/scripts/update-homebrew-cask.sh
+++ b/scripts/update-homebrew-cask.sh
@@ -16,7 +16,7 @@ cask "standlock" do
   version "${VERSION}"
   sha256 "${SHA256}"
 
-  url "https://github.com/yagizdo/StandLock/releases/download/v#{version}/StandLock-#{version}.zip",
+  url "https://github.com/yagizdo/StandLock/releases/download/v#{version}/StandLock-#{version}.dmg",
       verified: "github.com/yagizdo/StandLock/"
   name "StandLock"
   desc "Stand reminder and break screen for macOS"


### PR DESCRIPTION
## Summary

- Replace ZIP release artifact with DMG (drag-to-Applications install experience)
- Notarize the DMG directly instead of a temp ZIP of the .app -- stapled ticket enables offline Gatekeeper verification
- Reorder pipeline: create DMG → notarize → staple → compute SHA256 (post-staple)
- Update Sparkle appcast and Homebrew cask to reference .dmg URL
- Delete old `scripts/create-release-zip.sh`

## Pipeline order (post-export)

```
Fix Sparkle symlinks → Re-sign → Install create-dmg → Create DMG →
Notarize & staple DMG → SHA256 checksum → Sparkle appcast →
Release notes → GitHub Release → Homebrew cask
```

## Test plan

- [ ] Tag a release (e.g., `v1.x.x`) and verify the workflow completes
- [ ] GitHub Release contains `.dmg` and `.dmg.sha256` (no ZIP artifacts)
- [ ] DMG opens with StandLock.app on the left, Applications alias on the right
- [ ] `spctl --assess` passes on the .app inside the mounted DMG
- [ ] Sparkle update check downloads and installs from DMG
- [ ] `brew install --cask standlock` works with the new DMG URL