### PR TITLE
feat: screen sharing detection with post-deferral behavior

### DIFF
--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -58,6 +58,15 @@ struct DetectionSettingsView: View {
                     }
                 }
 
+                if coordinator.preferences.screenSharingDetectionEnabled {
+                    Picker("After sharing ends", selection: $coordinator.preferences.screenSharingPostDeferral) {
+                        Text("Start break").tag(PostDeferralBehavior.triggerBreak)
+                        Text("Skip break").tag(PostDeferralBehavior.skipBreak)
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.leading, 24)
+                }
+
                 detectionRow(
                     title: "Focus Mode",
                     description: "Defer breaks when Focus mode is active",

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -204,13 +204,23 @@ public final class BreakCoordinator: BreakCoordinating {
 
         if let deferral = shouldDefer(context: context) {
             statistics.breaksDeferred += 1
-            let nextAttempt = Date().addingTimeInterval(60)
-            eventContinuation.yield(.breakDeferred(deferral, nextAttempt: nextAttempt))
+            eventContinuation.yield(.breakDeferred(deferral, nextAttempt: Date().addingTimeInterval(10)))
             eventContinuation.yield(.statisticsUpdated(statistics))
             breakTimer = Task {
-                try? await Task.sleep(for: .seconds(60))
-                guard !Task.isCancelled else { return }
-                await triggerBreak(for: schedule)
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(10))
+                    guard !Task.isCancelled else { return }
+                    let freshContext = await self.detector.currentContext()
+                    if let newReason = self.shouldDefer(context: freshContext) {
+                        self.eventContinuation.yield(.breakDeferred(newReason, nextAttempt: Date().addingTimeInterval(10)))
+                    } else if self.shouldSkipAfterDeferral(reason: deferral) {
+                        self.scheduleNextBreak()
+                        return
+                    } else {
+                        await self.triggerBreak(for: schedule, context: freshContext)
+                        return
+                    }
+                }
             }
             return
         }
@@ -251,6 +261,10 @@ public final class BreakCoordinator: BreakCoordinating {
         if context.screenSharingActive && preferences.screenSharingDetectionEnabled { return .screenSharing }
         if context.focusModeActive && preferences.focusModeDetection == .deferBreak { return .focusMode }
         return nil
+    }
+
+    private func shouldSkipAfterDeferral(reason: DeferralReason) -> Bool {
+        reason == .screenSharing && preferences.screenSharingPostDeferral == .skipBreak
     }
 
     private func shouldReduce(context: DetectionContext) -> DisciplineLevel? {

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -22,17 +22,19 @@ public final class BreakCoordinator: BreakCoordinating {
     private var escalationTiers: [UUID: Int] = [:]
     public var exercises: [Exercise] = []
 
+    private let deferralPollingInterval: TimeInterval
     private let eventContinuation: AsyncStream<CoordinatorEvent>.Continuation
     public nonisolated let events: AsyncStream<CoordinatorEvent>
 
     public init(scheduler: any SchedulingEngine, detector: any ContextDetecting,
-                locker: any LockPresenting) {
+                locker: any LockPresenting, deferralPollingInterval: TimeInterval = 10) {
         var continuation: AsyncStream<CoordinatorEvent>.Continuation!
         self.events = AsyncStream { continuation = $0 }
         self.eventContinuation = continuation
         self.scheduler = scheduler
         self.detector = detector
         self.locker = locker
+        self.deferralPollingInterval = deferralPollingInterval
     }
 
     public func start(with schedules: [Schedule], preferences: AppPreferences) {
@@ -204,15 +206,15 @@ public final class BreakCoordinator: BreakCoordinating {
 
         if let deferral = shouldDefer(context: context) {
             statistics.breaksDeferred += 1
-            eventContinuation.yield(.breakDeferred(deferral, nextAttempt: Date().addingTimeInterval(10)))
+            eventContinuation.yield(.breakDeferred(deferral, nextAttempt: Date().addingTimeInterval(deferralPollingInterval)))
             eventContinuation.yield(.statisticsUpdated(statistics))
             breakTimer = Task {
                 while !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(10))
+                    try? await Task.sleep(for: .seconds(self.deferralPollingInterval))
                     guard !Task.isCancelled else { return }
                     let freshContext = await self.detector.currentContext()
                     if let newReason = self.shouldDefer(context: freshContext) {
-                        self.eventContinuation.yield(.breakDeferred(newReason, nextAttempt: Date().addingTimeInterval(10)))
+                        self.eventContinuation.yield(.breakDeferred(newReason, nextAttempt: Date().addingTimeInterval(self.deferralPollingInterval)))
                     } else if self.shouldSkipAfterDeferral(reason: deferral) {
                         self.scheduleNextBreak()
                         return

--- a/StandLockKit/Sources/Detection/ScreenSharingDetector.swift
+++ b/StandLockKit/Sources/Detection/ScreenSharingDetector.swift
@@ -1,13 +1,19 @@
 import AppKit
 
 public struct ScreenSharingDetector: Sendable {
-    public init() {}
+    private let processNames: @Sendable () -> [String]
+
+    public init() {
+        self.processNames = {
+            NSWorkspace.shared.runningApplications.compactMap { $0.executableURL?.lastPathComponent }
+        }
+    }
+
+    init(processNames: @escaping @Sendable () -> [String]) {
+        self.processNames = processNames
+    }
 
     public func isScreenBeingShared() async -> Bool {
-        let apps = NSWorkspace.shared.runningApplications
-        return apps.contains { app in
-            let exe = app.executableURL?.lastPathComponent
-            return exe == "ScreensharingAgent" || exe == "screencaptureui"
-        }
+        processNames().contains { $0 == "ScreensharingAgent" || $0 == "screencaptureui" }
     }
 }

--- a/StandLockKit/Sources/Detection/ScreenSharingDetector.swift
+++ b/StandLockKit/Sources/Detection/ScreenSharingDetector.swift
@@ -1,9 +1,13 @@
+import AppKit
+
 public struct ScreenSharingDetector: Sendable {
     public init() {}
 
     public func isScreenBeingShared() async -> Bool {
-        // v1: conservative default. Reliable detection requires Screen Recording
-        // permission and monitoring active capture sessions.
-        false
+        let apps = NSWorkspace.shared.runningApplications
+        return apps.contains { app in
+            let exe = app.executableURL?.lastPathComponent
+            return exe == "ScreensharingAgent" || exe == "screencaptureui"
+        }
     }
 }

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -12,6 +12,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
     public var calendarDetectionEnabled: Bool
     public var calendarLookAheadMinutes: Int
     public var screenSharingDetectionEnabled: Bool
+    public var screenSharingPostDeferral: PostDeferralBehavior
     public var focusModeDetection: DetectionBehavior
     public var idleDetectionEnabled: Bool
 
@@ -49,6 +50,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         calendarDetectionEnabled: Bool = true,
         calendarLookAheadMinutes: Int = 5,
         screenSharingDetectionEnabled: Bool = true,
+        screenSharingPostDeferral: PostDeferralBehavior = .triggerBreak,
         focusModeDetection: DetectionBehavior = .deferBreak,
         idleDetectionEnabled: Bool = true,
         pauseMediaDuringBreak: Bool = true,
@@ -65,6 +67,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         self.calendarDetectionEnabled = calendarDetectionEnabled
         self.calendarLookAheadMinutes = calendarLookAheadMinutes
         self.screenSharingDetectionEnabled = screenSharingDetectionEnabled
+        self.screenSharingPostDeferral = screenSharingPostDeferral
         self.focusModeDetection = focusModeDetection
         self.idleDetectionEnabled = idleDetectionEnabled
         self.pauseMediaDuringBreak = pauseMediaDuringBreak
@@ -78,7 +81,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         case strictEscapeHoldDuration
         case cameraDetection, microphoneDetection
         case calendarDetectionEnabled, calendarLookAheadMinutes
-        case screenSharingDetectionEnabled
+        case screenSharingDetectionEnabled, screenSharingPostDeferral
         case focusModeDetection, idleDetectionEnabled
         case pauseMediaDuringBreak, resumeMediaAfterBreak
         case resetIntervalOnSkip
@@ -100,6 +103,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         calendarDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .calendarDetectionEnabled) ?? true
         calendarLookAheadMinutes = try c.decodeIfPresent(Int.self, forKey: .calendarLookAheadMinutes) ?? 5
         screenSharingDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .screenSharingDetectionEnabled) ?? true
+        screenSharingPostDeferral = try c.decodeIfPresent(PostDeferralBehavior.self, forKey: .screenSharingPostDeferral) ?? .triggerBreak
         focusModeDetection = try c.decodeIfPresent(DetectionBehavior.self, forKey: .focusModeDetection) ?? .deferBreak
         idleDetectionEnabled = try c.decodeIfPresent(Bool.self, forKey: .idleDetectionEnabled) ?? true
         pauseMediaDuringBreak = try c.decodeIfPresent(Bool.self, forKey: .pauseMediaDuringBreak) ?? true
@@ -127,4 +131,9 @@ public enum DetectionBehavior: String, Codable, Sendable, CaseIterable {
     case deferBreak
     case reduceToGentle
     case ignore
+}
+
+public enum PostDeferralBehavior: String, Codable, Sendable {
+    case triggerBreak
+    case skipBreak
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -650,6 +650,125 @@ struct BreakCoordinatorTests {
         coordinator.stop()
     }
 
+    // MARK: - Post-Deferral Polling Tests
+
+    @Test @MainActor
+    func breakSkippedAfterScreenSharingDeferral() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(screenSharingActive: true)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(
+            scheduler: scheduler, detector: detector, locker: locker,
+            deferralPollingInterval: 0.1
+        )
+        let schedule = makeSchedule()
+        let prefs = AppPreferences(
+            screenSharingDetectionEnabled: true,
+            screenSharingPostDeferral: .skipBreak
+        )
+
+        var deferredEvents: [CoordinatorEvent] = []
+        var scheduledEvents: [CoordinatorEvent] = []
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakDeferred = event { deferredEvents.append(event) }
+                if case .nextBreakScheduled = event { scheduledEvents.append(event) }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(!deferredEvents.isEmpty)
+        #expect(!locker.showOverlayCalled)
+
+        let scheduledBefore = scheduledEvents.count
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        detector.contextToReturn = .clear
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(!locker.showOverlayCalled)
+        #expect(scheduledEvents.count > scheduledBefore)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
+    @Test @MainActor
+    func breakTriggersAfterScreenSharingDeferralClears() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(screenSharingActive: true)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(
+            scheduler: scheduler, detector: detector, locker: locker,
+            deferralPollingInterval: 0.1
+        )
+        let schedule = makeSchedule()
+        let prefs = AppPreferences(
+            screenSharingDetectionEnabled: true,
+            screenSharingPostDeferral: .triggerBreak
+        )
+
+        var deferredEvents: [CoordinatorEvent] = []
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakDeferred = event { deferredEvents.append(event) }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(!deferredEvents.isEmpty)
+        #expect(!locker.showOverlayCalled)
+
+        detector.contextToReturn = .clear
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
+    @Test @MainActor
+    func deferralContinuesWhileScreenSharingActive() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(screenSharingActive: true)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(
+            scheduler: scheduler, detector: detector, locker: locker,
+            deferralPollingInterval: 0.1
+        )
+        let schedule = makeSchedule()
+        let prefs = AppPreferences(screenSharingDetectionEnabled: true)
+
+        var deferredCount = 0
+        let listener = Task {
+            for await event in coordinator.events {
+                if case .breakDeferred = event { deferredCount += 1 }
+            }
+        }
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(500))
+
+        #expect(deferredCount >= 2)
+        #expect(!locker.showOverlayCalled)
+
+        coordinator.stop()
+        listener.cancel()
+    }
+
     @Test @MainActor
     func dailyBreakCapRespected() async {
         let scheduler = MockScheduler()

--- a/StandLockKit/Tests/DetectionTests/ScreenSharingDetectorTests.swift
+++ b/StandLockKit/Tests/DetectionTests/ScreenSharingDetectorTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import Detection
+
+@Suite("ScreenSharingDetector Tests")
+struct ScreenSharingDetectorTests {
+    @Test func returnsFalseWhenNoSharingProcesses() async {
+        let detector = ScreenSharingDetector()
+        let result = await detector.isScreenBeingShared()
+        #expect(!result)
+    }
+}

--- a/StandLockKit/Tests/DetectionTests/ScreenSharingDetectorTests.swift
+++ b/StandLockKit/Tests/DetectionTests/ScreenSharingDetectorTests.swift
@@ -4,7 +4,25 @@ import Testing
 @Suite("ScreenSharingDetector Tests")
 struct ScreenSharingDetectorTests {
     @Test func returnsFalseWhenNoSharingProcesses() async {
-        let detector = ScreenSharingDetector()
+        let detector = ScreenSharingDetector(processNames: { ["Finder", "Safari", "Xcode"] })
+        let result = await detector.isScreenBeingShared()
+        #expect(!result)
+    }
+
+    @Test func returnsTrueWhenScreensharingAgentRunning() async {
+        let detector = ScreenSharingDetector(processNames: { ["Finder", "ScreensharingAgent", "Xcode"] })
+        let result = await detector.isScreenBeingShared()
+        #expect(result)
+    }
+
+    @Test func returnsTrueWhenScreencaptureuiRunning() async {
+        let detector = ScreenSharingDetector(processNames: { ["Finder", "screencaptureui"] })
+        let result = await detector.isScreenBeingShared()
+        #expect(result)
+    }
+
+    @Test func returnsFalseWhenProcessListEmpty() async {
+        let detector = ScreenSharingDetector(processNames: { [] })
         let result = await detector.isScreenBeingShared()
         #expect(!result)
     }


### PR DESCRIPTION
## Summary
- Detect active screen sharing via `ScreensharingAgent` / `screencaptureui` process lookup and defer breaks accordingly
- Poll deferred break context every 10s instead of fixed 60s retry for faster UI updates
- Add user preference for post-deferral behavior: start break immediately or skip silently when sharing ends

## Test plan
- [x] Build succeeds
- [x] 86 unit tests pass
- [x] Enable screen sharing detection in Detection settings
- [x] Start screen sharing during a scheduled break window — verify break defers with "Break waiting / Screen sharing active"
- [x] Stop screen sharing — verify UI updates within ~10s
- [x] Toggle "After sharing ends" between "Start break" and "Skip break" and verify each behavior