### PR TITLE
refactor: consolidate permission system and add gated toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ ExportOptions.plist
 *.swo
 *~
 .vscode/
+buildServer.json
 
 # Personal configs
 *.xcuserstate

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -41,6 +41,8 @@ final class AppCoordinator: ObservableObject {
     @Published var hasCompletedOnboarding: Bool = false
     @Published private(set) var breakProgress: Double = 0
 
+    let permissionChecker = PermissionChecker()
+
     private var coordinator: BreakCoordinator?
     private let overlayController = OverlayWindowController()
     private var eventListenerTask: Task<Void, Never>?
@@ -53,6 +55,7 @@ final class AppCoordinator: ObservableObject {
         loadExercises()
         loadData()
         startProgressTimer()
+        Task { await permissionChecker.pollContinuously() }
         if !schedules.isEmpty {
             startCoordinator()
         }
@@ -288,7 +291,9 @@ final class AppCoordinator: ObservableObject {
         window.titleVisibility = .hidden
         window.isReleasedWhenClosed = false
         window.contentView = NSHostingView(
-            rootView: OnboardingView().environmentObject(self)
+            rootView: OnboardingView()
+                .environmentObject(self)
+                .environmentObject(permissionChecker)
         )
         window.center()
 

--- a/StandLock/AppState/PermissionChecker.swift
+++ b/StandLock/AppState/PermissionChecker.swift
@@ -49,6 +49,12 @@ final class PermissionChecker: ObservableObject {
         inputMonitoringGranted = CGPreflightListenEventAccess()
         accessibilityGranted = AXIsProcessTrusted()
         calendarStatus = EKEventStore.authorizationStatus(for: .event)
+        let probe = probeInputMonitoringAccess()
+        if probe {
+            inputMonitoringGranted = true
+            inputMonitoringProbeSucceeded = true
+            lastProbeTime = Date()
+        }
     }
 
     var accessibilityStatus: PermissionStatus {
@@ -110,17 +116,18 @@ final class PermissionChecker: ObservableObject {
     }
 
     private func updateInputMonitoringProbe() {
-        guard inputMonitoringGranted else {
-            inputMonitoringProbeSucceeded = false
-            return
-        }
         guard Date().timeIntervalSince(lastProbeTime) >= probeInterval else { return }
         lastProbeTime = Date()
-        inputMonitoringProbeSucceeded = probeInputMonitoringAccess()
+        let result = probeInputMonitoringAccess()
+        inputMonitoringProbeSucceeded = result
+        if result && !inputMonitoringGranted {
+            inputMonitoringGranted = true
+        }
     }
 
     func refreshStatus() {
-        inputMonitoringGranted = CGPreflightListenEventAccess()
+        let preflight = CGPreflightListenEventAccess()
+        inputMonitoringGranted = preflight || inputMonitoringProbeSucceeded
         accessibilityGranted = AXIsProcessTrusted()
         calendarStatus = EKEventStore.authorizationStatus(for: .event)
     }
@@ -207,6 +214,35 @@ final class PermissionChecker: ObservableObject {
         }
     }
 
+    // MARK: - Feature Gates
+
+    var idleDetectionAvailable: Bool { inputMonitoringGranted }
+    var strictModeAvailable: Bool { accessibilityGranted }
+    var calendarIntegrationAvailable: Bool { CalendarDetector.isAuthorized(calendarStatus) }
+
+    func gatedToggle(
+        for preference: Binding<Bool>,
+        requires permission: PermissionType,
+        onDenied: @escaping () -> Void
+    ) -> Binding<Bool> {
+        let available: Bool
+        switch permission {
+        case .inputMonitoring: available = idleDetectionAvailable
+        case .accessibility: available = strictModeAvailable
+        case .calendar: available = calendarIntegrationAvailable
+        }
+        return Binding(
+            get: { available && preference.wrappedValue },
+            set: { newValue in
+                if newValue && !available {
+                    onDenied()
+                } else {
+                    preference.wrappedValue = newValue
+                }
+            }
+        )
+    }
+
     private func openSystemSettings(for permission: PermissionType) {
         for url in permission.settingsURLs {
             if NSWorkspace.shared.open(url) { return }
@@ -223,7 +259,12 @@ final class PermissionChecker: ObservableObject {
     }
 
     func requestInputMonitoring() {
-        _ = probeInputMonitoringAccess()
+        if probeInputMonitoringAccess() {
+            inputMonitoringGranted = true
+            inputMonitoringProbeSucceeded = true
+            lastProbeTime = Date()
+            return
+        }
 
         if CGPreflightListenEventAccess() {
             refreshStatus()

--- a/StandLock/StandLockApp.swift
+++ b/StandLock/StandLockApp.swift
@@ -10,6 +10,7 @@ struct StandLockApp: App {
         MenuBarExtra {
             MenuBarView()
                 .environmentObject(appCoordinator)
+                .environmentObject(appCoordinator.permissionChecker)
                 .environmentObject(appDelegate.updateObserver)
         } label: {
             Image(nsImage: MenuBarIcon.make(progress: appCoordinator.breakProgress))
@@ -19,6 +20,7 @@ struct StandLockApp: App {
         Settings {
             SettingsView()
                 .environmentObject(appCoordinator)
+                .environmentObject(appCoordinator.permissionChecker)
         }
         .commands {
             CommandGroup(after: .appInfo) {

--- a/StandLock/Views/Onboarding/PermissionsStepView.swift
+++ b/StandLock/Views/Onboarding/PermissionsStepView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PermissionsStepView: View {
-    @StateObject private var checker = PermissionChecker()
+    @EnvironmentObject private var checker: PermissionChecker
     var onContinue: () -> Void
 
     var body: some View {
@@ -10,7 +10,7 @@ struct PermissionsStepView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
 
-            Text("StandLock works best with these permissions. You can grant them now or later in Settings.")
+            Text("StandLock works without any permissions. Each one unlocks an extra feature. You can grant them now or later in Settings.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -20,7 +20,7 @@ struct PermissionsStepView: View {
                 permissionCard(
                     icon: "keyboard",
                     name: "Input Monitoring",
-                    description: "Detect keyboard activity for idle detection and escape combo.",
+                    description: "Enables idle detection and the escape key combo.",
                     status: checker.inputMonitoringStatus,
                     action: { checker.requestInputMonitoring() },
                     restartAction: { checker.relaunchApp() }
@@ -40,7 +40,6 @@ struct PermissionsStepView: View {
                     name: "Calendar Access",
                     description: "Defer breaks during calendar events.",
                     status: checker.calendarPermissionStatus,
-                    isOptional: true,
                     action: { checker.requestCalendar() },
                     restartAction: { checker.relaunchApp() }
                 )
@@ -60,7 +59,6 @@ struct PermissionsStepView: View {
         }
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task { await checker.pollContinuously() }
     }
 
     private func permissionCard(
@@ -68,7 +66,6 @@ struct PermissionsStepView: View {
         name: String,
         description: String,
         status: PermissionStatus,
-        isOptional: Bool = false,
         action: @escaping () -> Void,
         restartAction: @escaping () -> Void
     ) -> some View {
@@ -82,7 +79,7 @@ struct PermissionsStepView: View {
                 HStack(spacing: 6) {
                     Text(name)
                         .font(.body.weight(.medium))
-                    statusBadge(for: status, isOptional: isOptional)
+                    statusBadge(for: status)
                 }
                 Text(description)
                     .font(.caption)
@@ -104,22 +101,16 @@ struct PermissionsStepView: View {
     }
 
     @ViewBuilder
-    private func statusBadge(for status: PermissionStatus, isOptional: Bool) -> some View {
+    private func statusBadge(for status: PermissionStatus) -> some View {
         switch status {
         case .granted:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(.green)
                 .font(.caption)
         case .notGranted:
-            if isOptional {
-                Image(systemName: "circle")
-                    .foregroundStyle(.blue)
-                    .font(.caption)
-            } else {
-                Image(systemName: "exclamationmark.circle")
-                    .foregroundStyle(.orange)
-                    .font(.caption)
-            }
+            Image(systemName: "circle")
+                .foregroundStyle(.blue)
+                .font(.caption)
         case .denied:
             Image(systemName: "xmark.circle.fill")
                 .foregroundStyle(.red)

--- a/StandLock/Views/Settings/DetectionSettingsView.swift
+++ b/StandLock/Views/Settings/DetectionSettingsView.swift
@@ -3,6 +3,10 @@ import StandLockCore
 
 struct DetectionSettingsView: View {
     @EnvironmentObject private var coordinator: AppCoordinator
+    @EnvironmentObject private var permissionChecker: PermissionChecker
+    @State private var showCalendarPermissionAlert = false
+    @State private var showAccessibilityAlert = false
+    @State private var showInputMonitoringAlert = false
 
     var body: some View {
         Form {
@@ -23,7 +27,11 @@ struct DetectionSettingsView: View {
             }
 
             Section("Calendar & Focus") {
-                Toggle(isOn: $coordinator.preferences.calendarDetectionEnabled) {
+                Toggle(isOn: permissionChecker.gatedToggle(
+                    for: $coordinator.preferences.calendarDetectionEnabled,
+                    requires: .calendar,
+                    onDenied: { showCalendarPermissionAlert = true }
+                )) {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Calendar Integration")
@@ -36,7 +44,8 @@ struct DetectionSettingsView: View {
                     }
                 }
 
-                if coordinator.preferences.calendarDetectionEnabled {
+                if permissionChecker.calendarIntegrationAvailable
+                    && coordinator.preferences.calendarDetectionEnabled {
                     Stepper(
                         "Look-ahead: \(coordinator.preferences.calendarLookAheadMinutes) min",
                         value: $coordinator.preferences.calendarLookAheadMinutes,
@@ -105,7 +114,11 @@ struct DetectionSettingsView: View {
                     .padding(.leading, 24)
                 }
 
-                Toggle(isOn: $coordinator.preferences.idleDetectionEnabled) {
+                Toggle(isOn: permissionChecker.gatedToggle(
+                    for: $coordinator.preferences.idleDetectionEnabled,
+                    requires: .inputMonitoring,
+                    onDenied: { showInputMonitoringAlert = true }
+                )) {
                     Label {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Idle as Break")
@@ -158,8 +171,44 @@ struct DetectionSettingsView: View {
             }
         }
         .formStyle(.grouped)
+        .onChange(of: coordinator.preferences.escalationLevel) { newLevel in
+            if newLevel == .strict && !permissionChecker.strictModeAvailable {
+                coordinator.preferences.escalationLevel = .firm
+                showAccessibilityAlert = true
+            }
+        }
         .onChange(of: coordinator.preferences) { _ in
             coordinator.savePreferences()
+        }
+        .alert("Calendar Permission Required", isPresented: $showCalendarPermissionAlert) {
+            Button("Open System Settings") {
+                for url in PermissionType.calendar.settingsURLs {
+                    if NSWorkspace.shared.open(url) { break }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Calendar Integration requires calendar access. Grant it in System Settings to enable this feature.")
+        }
+        .alert("Input Monitoring Required", isPresented: $showInputMonitoringAlert) {
+            Button("Open System Settings") {
+                for url in PermissionType.inputMonitoring.settingsURLs {
+                    if NSWorkspace.shared.open(url) { break }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This feature requires Input Monitoring permission. Grant it in System Settings to enable.")
+        }
+        .alert("Accessibility Permission Required", isPresented: $showAccessibilityAlert) {
+            Button("Open System Settings") {
+                for url in PermissionType.accessibility.settingsURLs {
+                    if NSWorkspace.shared.open(url) { break }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Strict mode requires Accessibility permission to block input during breaks.")
         }
     }
 

--- a/StandLock/Views/Settings/DisciplineLevelPicker.swift
+++ b/StandLock/Views/Settings/DisciplineLevelPicker.swift
@@ -4,7 +4,7 @@ import StandLockCore
 
 struct DisciplineLevelPicker: View {
     @Binding var selection: DisciplineLevel
-    @StateObject private var checker = PermissionChecker()
+    @EnvironmentObject private var checker: PermissionChecker
     @State private var showPermissionAlert = false
 
     var body: some View {
@@ -34,7 +34,6 @@ struct DisciplineLevelPicker: View {
         } message: {
             Text("Strict mode requires Accessibility permission to block input during breaks.")
         }
-        .task { await checker.pollContinuously() }
     }
 }
 

--- a/StandLock/Views/Settings/PermissionsView.swift
+++ b/StandLock/Views/Settings/PermissionsView.swift
@@ -1,36 +1,25 @@
 import SwiftUI
 
 struct PermissionsView: View {
-    @StateObject private var checker = PermissionChecker()
+    @EnvironmentObject private var checker: PermissionChecker
 
     var body: some View {
         Form {
             Section {
                 PermissionRow(
                     title: "Input Monitoring",
-                    description: "Detect keyboard activity for idle detection and escape combo. You'll need to enable it in System Settings.",
+                    description: "Enables idle detection and the escape key combo.",
                     systemImage: "keyboard",
                     status: checker.inputMonitoringStatus,
                     settingsURLs: PermissionType.inputMonitoring.settingsURLs,
                     action: { checker.requestInputMonitoring() },
                     restartAction: { checker.relaunchApp() }
                 )
-            } header: {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Grant permissions that match your usage.")
-                        .textCase(nil)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .padding(.bottom, 4)
-                    Text("Recommended")
-                }
-            }
 
-            Section("Optional") {
                 PermissionRow(
                     title: "Accessibility",
-                    description: "Enables Strict mode to fully block keyboard and mouse input. Requires manual toggle in System Settings.",
-                    systemImage: "hand.raised.circle",
+                    description: "Enables Strict mode to fully block keyboard and mouse input.",
+                  systemImage: "hand.raised.circle",
                     status: checker.accessibilityStatus,
                     settingsURLs: PermissionType.accessibility.settingsURLs,
                     action: { checker.requestAccessibility() },
@@ -39,17 +28,21 @@ struct PermissionsView: View {
 
                 PermissionRow(
                     title: "Calendar Access",
-                    description: "Read your calendar to defer breaks during meetings.",
+                    description: "Defer breaks during calendar events.",
                     systemImage: "calendar",
                     status: checker.calendarPermissionStatus,
                     settingsURLs: PermissionType.calendar.settingsURLs,
                     action: { checker.requestCalendar() },
                     restartAction: { checker.relaunchApp() }
                 )
+            } header: {
+                Text("Grant permissions that match your usage. StandLock works without any of them.")
+                    .textCase(nil)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
-        .task { await checker.pollContinuously() }
     }
 }
 

--- a/StandLock/Views/Settings/PermissionsView.swift
+++ b/StandLock/Views/Settings/PermissionsView.swift
@@ -19,7 +19,7 @@ struct PermissionsView: View {
                 PermissionRow(
                     title: "Accessibility",
                     description: "Enables Strict mode to fully block keyboard and mouse input.",
-                  systemImage: "hand.raised.circle",
+                    systemImage: "hand.raised.circle",
                     status: checker.accessibilityStatus,
                     settingsURLs: PermissionType.accessibility.settingsURLs,
                     action: { checker.requestAccessibility() },

--- a/StandLockKit/Tests/StandLockCoreTests/GatedToggleBindingTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/GatedToggleBindingTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import SwiftUI
+
+/// Tests for the gated toggle binding pattern used by PermissionChecker.gatedToggle().
+@Suite("Gated Toggle Binding")
+@MainActor
+struct GatedToggleBindingTests {
+
+    private func makeBinding(
+        available: Bool,
+        preference: Binding<Bool>,
+        onDenied: @escaping () -> Void
+    ) -> Binding<Bool> {
+        Binding(
+            get: { available && preference.wrappedValue },
+            set: { newValue in
+                if newValue && !available {
+                    onDenied()
+                } else {
+                    preference.wrappedValue = newValue
+                }
+            }
+        )
+    }
+
+    // MARK: - Getter
+
+    @Test func getterReturnsTrueWhenAvailableAndPreferenceOn() {
+        var value = true
+        let pref = Binding(get: { value }, set: { value = $0 })
+        let binding = makeBinding(available: true, preference: pref, onDenied: {})
+        #expect(binding.wrappedValue == true)
+    }
+
+    @Test func getterReturnsFalseWhenAvailableButPreferenceOff() {
+        var value = false
+        let pref = Binding(get: { value }, set: { value = $0 })
+        let binding = makeBinding(available: true, preference: pref, onDenied: {})
+        #expect(binding.wrappedValue == false)
+    }
+
+    @Test func getterReturnsFalseWhenUnavailableRegardlessOfPreference() {
+        var value = true
+        let pref = Binding(get: { value }, set: { value = $0 })
+        let binding = makeBinding(available: false, preference: pref, onDenied: {})
+        #expect(binding.wrappedValue == false)
+    }
+
+    // MARK: - Setter
+
+    @Test func setterUpdatesPreferenceWhenAvailable() {
+        var value = false
+        let pref = Binding(get: { value }, set: { value = $0 })
+        var denied = false
+        let binding = makeBinding(available: true, preference: pref, onDenied: { denied = true })
+
+        binding.wrappedValue = true
+        #expect(value == true)
+        #expect(denied == false)
+    }
+
+    @Test func setterCallsDeniedWhenEnablingWhileUnavailable() {
+        var value = false
+        let pref = Binding(get: { value }, set: { value = $0 })
+        var denied = false
+        let binding = makeBinding(available: false, preference: pref, onDenied: { denied = true })
+
+        binding.wrappedValue = true
+        #expect(value == false)
+        #expect(denied == true)
+    }
+
+    @Test func setterAllowsDisablingWhenUnavailable() {
+        var value = true
+        let pref = Binding(get: { value }, set: { value = $0 })
+        var denied = false
+        let binding = makeBinding(available: false, preference: pref, onDenied: { denied = true })
+
+        binding.wrappedValue = false
+        #expect(value == false)
+        #expect(denied == false)
+    }
+
+    @Test func setterAllowsDisablingWhenAvailable() {
+        var value = true
+        let pref = Binding(get: { value }, set: { value = $0 })
+        let binding = makeBinding(available: true, preference: pref, onDenied: {})
+
+        binding.wrappedValue = false
+        #expect(value == false)
+    }
+}


### PR DESCRIPTION
## Summary

- PermissionChecker artik tek bir shared instance olarak AppCoordinator'da yasiyor; her view kendi instance'ini olusturmak yerine EnvironmentObject ile paylasilan instance'i kullaniyor
- Input Monitoring tespiti iyilestirildi: CGPreflightListenEventAccess() stale false dondugunde event tap probe fallback olarak calisiyor
- Detection ayarlarindaki toggle'lar (Calendar Integration, Idle as Break, Strict escalation) artik ilgili izin verilmeden etkinlestirilemiyor; izin yoksa kullaniciyi System Settings'e yonlendiren alert gosteriyor

## Test plan

- [ ] Uygulama baslatildiginda Permissions sekmesinde izin durumlari dogru goruntuleniyor
- [ ] Onboarding'de izin durumlari dogru goruntuleniyor
- [ ] Detection ayarlarinda izin verilmemis bir toggle'a basildiginda alert gosteriyor
- [ ] Input Monitoring izni verildikten sonra polling ile durum guncelleniyor
- [ ] Strict mode secildiginde Accessibility izni yoksa firm'e geri donuyor