### PR TITLE
ci: add test gate for PRs and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,18 @@ env:
   TEAM_ID: F475N5N7V6
 
 jobs:
+  test:
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run StandLockKit tests
+        run: swift test --package-path StandLockKit
+
   release:
+    needs: test
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run StandLockKit tests
+        run: swift test --package-path StandLockKit

--- a/StandLock.xcodeproj/project.pbxproj
+++ b/StandLock.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		24E7C22FA25D7BF0111E50A7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_DISPLAY_NAME = StandLock;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = StandLock/StandLock.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -373,6 +374,7 @@
 		3C3BFC828EAE81A230208DC6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_DISPLAY_NAME = "StandLock Debug";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = StandLock/StandLock.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -382,7 +384,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yagizdokumaci.standlock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yagizdokumaci.standlock.debug;
 				PRODUCT_NAME = StandLock;
 				SDKROOT = macosx;
 				SWIFT_STRICT_CONCURRENCY = complete;

--- a/StandLock/Info.plist
+++ b/StandLock/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleDisplayName</key>
-	<string>StandLock</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- Add `tests.yml` workflow that runs StandLockKit tests on every PR and push to main
- Add test job to `release.yml` as a gate -- release won't proceed if tests fail (`needs: test`)
- Use concurrency groups to auto-cancel stale workflow runs on the same branch
- Use separate bundle ID (`com.yagizdokumaci.standlock.debug`) for debug builds so debug and release instances can run side by side with isolated UserDefaults, login items, and Sparkle state

## Test plan
- [ ] Verify Tests workflow triggers when a PR is opened
- [ ] Verify release job is blocked when tests fail