### PR TITLE
fix: disable permission-dependent features when permission is revoked

### DIFF
--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -137,10 +137,8 @@ final class AppCoordinator: ObservableObject {
             savePreferences()
         }
 
-        let strictAllowed = permissionChecker.strictModeAvailable
-            && permissionChecker.idleDetectionAvailable
         var schedulesChanged = false
-        if !strictAllowed {
+        if !permissionChecker.strictModeAvailable {
             for i in schedules.indices where schedules[i].disciplineLevel == .strict {
                 schedules[i].disciplineLevel = .gentle
                 schedulesChanged = true
@@ -160,6 +158,7 @@ final class AppCoordinator: ObservableObject {
     // MARK: - Coordinator Lifecycle
 
     private func startCoordinator() {
+        stopCoordinator()
         let scheduler = ScheduleEvaluator()
         let detector = CompositeDetector(
             calendar: CalendarDetector(lookAheadMinutes: preferences.calendarLookAheadMinutes)

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import Coordination
 import StandLockCore
 import Scheduling
@@ -50,11 +51,18 @@ final class AppCoordinator: ObservableObject {
     private var loadedExercises: [Exercise] = []
     private var onboardingWindow: NSWindow?
     private var onboardingWindowDelegate: OnboardingWindowCloseDelegate?
+    private var permissionSyncCancellable: AnyCancellable?
 
     init() {
         loadExercises()
         loadData()
+        syncPreferencesWithPermissions()
         startProgressTimer()
+        permissionSyncCancellable = permissionChecker.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.syncPreferencesWithPermissions()
+            }
         Task { await permissionChecker.pollContinuously() }
         if !schedules.isEmpty {
             startCoordinator()
@@ -113,6 +121,35 @@ final class AppCoordinator: ObservableObject {
         guard let data = try? JSONEncoder().encode(preferences) else { return }
         UserDefaults.standard.set(data, forKey: "preferences")
         coordinator?.updatePreferences(preferences)
+    }
+
+    private func syncPreferencesWithPermissions() {
+        var prefsChanged = false
+        if preferences.idleDetectionEnabled && !permissionChecker.idleDetectionAvailable {
+            preferences.idleDetectionEnabled = false
+            prefsChanged = true
+        }
+        if preferences.calendarDetectionEnabled && !permissionChecker.calendarIntegrationAvailable {
+            preferences.calendarDetectionEnabled = false
+            prefsChanged = true
+        }
+        if prefsChanged {
+            savePreferences()
+        }
+
+        let strictAllowed = permissionChecker.strictModeAvailable
+            && permissionChecker.idleDetectionAvailable
+        var schedulesChanged = false
+        if !strictAllowed {
+            for i in schedules.indices where schedules[i].disciplineLevel == .strict {
+                schedules[i].disciplineLevel = .gentle
+                schedulesChanged = true
+            }
+        }
+        if schedulesChanged {
+            saveSchedules()
+            restartCoordinator()
+        }
     }
 
     func saveStatistics() {

--- a/StandLock/AppState/PermissionChecker.swift
+++ b/StandLock/AppState/PermissionChecker.swift
@@ -217,7 +217,7 @@ final class PermissionChecker: ObservableObject {
     // MARK: - Feature Gates
 
     var idleDetectionAvailable: Bool { inputMonitoringGranted }
-    var strictModeAvailable: Bool { accessibilityGranted }
+    var strictModeAvailable: Bool { accessibilityGranted && inputMonitoringGranted }
     var calendarIntegrationAvailable: Bool { CalendarDetector.isAuthorized(calendarStatus) }
 
     func gatedToggle(

--- a/StandLock/Views/Onboarding/PermissionsStepView.swift
+++ b/StandLock/Views/Onboarding/PermissionsStepView.swift
@@ -10,7 +10,7 @@ struct PermissionsStepView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
 
-            Text("StandLock works without any permissions. Each one unlocks an extra feature. You can grant them now or later in Settings.")
+            Text("Each permission unlocks a feature. You can grant them now or later in Settings.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/StandLock/Views/Settings/DisciplineLevelPicker.swift
+++ b/StandLock/Views/Settings/DisciplineLevelPicker.swift
@@ -7,10 +7,6 @@ struct DisciplineLevelPicker: View {
     @EnvironmentObject private var checker: PermissionChecker
     @State private var showPermissionAlert = false
 
-    private var strictAvailable: Bool {
-        checker.accessibilityGranted && checker.inputMonitoringGranted
-    }
-
     private var missingPermissionMessage: String {
         if !checker.accessibilityGranted && !checker.inputMonitoringGranted {
             return "Strict mode requires Accessibility and Input Monitoring permissions."
@@ -27,10 +23,10 @@ struct DisciplineLevelPicker: View {
                 LevelCard(
                     level: level,
                     isSelected: selection == level,
-                    isDisabled: level == .strict && !strictAvailable
+                    isDisabled: level == .strict && !checker.strictModeAvailable
                 )
                 .onTapGesture {
-                    if level == .strict && !strictAvailable {
+                    if level == .strict && !checker.strictModeAvailable {
                         showPermissionAlert = true
                     } else {
                         selection = level

--- a/StandLock/Views/Settings/DisciplineLevelPicker.swift
+++ b/StandLock/Views/Settings/DisciplineLevelPicker.swift
@@ -7,16 +7,30 @@ struct DisciplineLevelPicker: View {
     @EnvironmentObject private var checker: PermissionChecker
     @State private var showPermissionAlert = false
 
+    private var strictAvailable: Bool {
+        checker.accessibilityGranted && checker.inputMonitoringGranted
+    }
+
+    private var missingPermissionMessage: String {
+        if !checker.accessibilityGranted && !checker.inputMonitoringGranted {
+            return "Strict mode requires Accessibility and Input Monitoring permissions."
+        } else if !checker.accessibilityGranted {
+            return "Strict mode requires Accessibility permission to block input during breaks."
+        } else {
+            return "Strict mode requires Input Monitoring permission for the escape key combo."
+        }
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             ForEach(DisciplineLevel.allCases, id: \.self) { level in
                 LevelCard(
                     level: level,
                     isSelected: selection == level,
-                    isDisabled: level == .strict && !checker.accessibilityGranted
+                    isDisabled: level == .strict && !strictAvailable
                 )
                 .onTapGesture {
-                    if level == .strict && !checker.accessibilityGranted {
+                    if level == .strict && !strictAvailable {
                         showPermissionAlert = true
                     } else {
                         selection = level
@@ -24,15 +38,21 @@ struct DisciplineLevelPicker: View {
                 }
             }
         }
-        .alert("Accessibility Permission Required", isPresented: $showPermissionAlert) {
+        .alert("Permission Required", isPresented: $showPermissionAlert) {
             Button("Open System Settings") {
-                for url in PermissionType.accessibility.settingsURLs {
-                    if NSWorkspace.shared.open(url) { break }
+                if !checker.accessibilityGranted {
+                    for url in PermissionType.accessibility.settingsURLs {
+                        if NSWorkspace.shared.open(url) { break }
+                    }
+                } else {
+                    for url in PermissionType.inputMonitoring.settingsURLs {
+                        if NSWorkspace.shared.open(url) { break }
+                    }
                 }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Strict mode requires Accessibility permission to block input during breaks.")
+            Text(missingPermissionMessage)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Sync preferences with permission state on startup and on every permission poll cycle
- Idle detection is disabled when Input Monitoring permission is missing
- Calendar integration is disabled when Calendar permission is missing
- Strict mode schedules drop to Gentle when Accessibility or Input Monitoring is missing
- DisciplineLevelPicker now checks both Accessibility and Input Monitoring for Strict, with context-aware alert messages
- Onboarding permission step updated: all permissions are optional, no gate on Continue

## Test plan
- [ ] Revoke Input Monitoring → verify Idle as Break toggle turns off
- [ ] Revoke Calendar permission → verify Calendar Integration toggle turns off
- [ ] Revoke Accessibility → verify Strict schedules drop to Gentle
- [ ] Try enabling gated features without permission → verify alert appears
- [ ] Grant permission back → verify feature stays off until manually enabled