### PR TITLE
feat: crate opening skip mechanism for Gentle mode

### DIFF
--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -80,6 +80,13 @@ struct ActionArea: View {
                 maxAttempts: attempts,
                 onDismiss: onDismiss
             )
+        case .crateOpening(let slotCount, let maxAttempts):
+            CrateOpeningDismissView(
+                palette: palette,
+                slotCount: slotCount,
+                maxAttempts: maxAttempts,
+                onDismiss: onDismiss
+            )
         case .keyCombo(let duration):
             KeyComboDismissView(
                 palette: palette, holdDuration: duration,
@@ -345,6 +352,204 @@ private struct FindButtonDismissView: View {
                 isProcessing = false
             }
         }
+    }
+}
+
+// MARK: - Crate Opening
+
+private struct CrateOpeningDismissView: View {
+    let palette: BreakPalette
+    let slotCount: Int
+    let maxAttempts: Int
+    let onDismiss: () -> Void
+
+    private let slotWidth: CGFloat = 52
+    private let slotSpacing: CGFloat = 4
+    private let viewportWidth: CGFloat = 420
+    private let spinDuration: TimeInterval = 4.0
+    private let greenSlotOffset = 4
+
+    @State private var stripOffset: CGFloat = 0
+    @State private var currentAttempt = 0
+    @State private var isSpinning = false
+    @State private var landed: Bool? = nil
+    @State private var usedAttempts: [Bool]
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(palette: BreakPalette, slotCount: Int, maxAttempts: Int, onDismiss: @escaping () -> Void) {
+        self.palette = palette
+        self.slotCount = slotCount
+        self.maxAttempts = maxAttempts
+        self.onDismiss = onDismiss
+        self._usedAttempts = State(initialValue: Array(repeating: false, count: maxAttempts))
+    }
+
+    private var totalSlots: Int { slotCount * 3 }
+    private var slotStride: CGFloat { slotWidth + slotSpacing }
+
+    private var greenIndices: Set<Int> {
+        Set((0..<3).map { $0 * slotCount + greenSlotOffset })
+    }
+
+    private var headerText: String {
+        switch landed {
+        case nil:
+            return currentAttempt == 0 ? "Try your luck!" : "Try again!"
+        case false:
+            return "Not this time..."
+        case true:
+            return "Lucky!"
+        }
+    }
+
+    private var subtitleText: String {
+        if currentAttempt == 0 { return "One of these lets you skip..." }
+        let remaining = maxAttempts - currentAttempt
+        return remaining == 1 ? "Last chance..." : "\(remaining) chances left"
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(headerText)
+                .font(BreakTypography.label(size: 14, weight: .medium))
+                .foregroundStyle(palette.ink)
+                .contentTransition(.interpolate)
+                .animation(.easeInOut(duration: 0.2), value: landed)
+                .animation(.easeInOut(duration: 0.2), value: currentAttempt)
+
+            HStack(spacing: 6) {
+                ForEach(0..<maxAttempts, id: \.self) { i in
+                    Circle()
+                        .fill(usedAttempts[i] ? palette.paperEdge : palette.accent)
+                        .frame(width: 8, height: 8)
+                }
+            }
+
+            VStack(spacing: 4) {
+                IndicatorTriangle()
+                    .fill(palette.ink)
+                    .frame(width: 12, height: 8)
+
+                HStack(spacing: slotSpacing) {
+                    ForEach(0..<totalSlots, id: \.self) { i in
+                        let isGreen = greenIndices.contains(i)
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(isGreen ? Color.green.opacity(0.8) : Color.red.opacity(0.8))
+                            .frame(width: slotWidth, height: 48)
+                            .overlay(
+                                Text(isGreen ? "Skip" : "\u{2715}")
+                                    .font(BreakTypography.label(size: isGreen ? 13 : 16, weight: .medium))
+                                    .foregroundStyle(.white)
+                            )
+                    }
+                }
+                .offset(x: stripOffset)
+                .frame(width: viewportWidth, height: 60, alignment: .leading)
+                .clipped()
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(palette.paper.opacity(0.3))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(palette.paperEdge, lineWidth: 1)
+                )
+            }
+
+            Text(subtitleText)
+                .font(BreakTypography.label(size: 11))
+                .foregroundStyle(palette.inkFaint)
+                .contentTransition(.interpolate)
+                .animation(.easeInOut(duration: 0.2), value: currentAttempt)
+
+            Button(action: spin) {
+                VStack(spacing: 4) {
+                    Text(currentAttempt == 0 ? "Spin \u{2192}" : "Try again \u{2192}")
+                        .font(BreakTypography.label(size: 14, weight: .medium))
+                        .foregroundStyle(palette.ink)
+                    Rectangle()
+                        .fill(palette.ink)
+                        .frame(height: 1)
+                }
+                .fixedSize()
+            }
+            .buttonStyle(.plain)
+            .disabled(isSpinning)
+            .opacity(isSpinning ? 0.4 : 1)
+        }
+        .transition(.opacity)
+    }
+
+    private func spin() {
+        guard !isSpinning else { return }
+        isSpinning = true
+        landed = nil
+
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            stripOffset = 0
+        }
+
+        let greens = Array(greenIndices).filter { $0 >= slotCount }
+        let nonGreens = (slotCount..<totalSlots).filter { !greenIndices.contains($0) }
+
+        let targetIndex: Int
+        switch currentAttempt {
+        case 0:
+            targetIndex = Int.random(in: slotCount..<totalSlots)
+        case 1:
+            targetIndex = Double.random(in: 0..<1) < 0.35
+                ? greens.randomElement()!
+                : nonGreens.randomElement()!
+        default:
+            targetIndex = greens.randomElement()!
+        }
+
+        let jitter = CGFloat.random(in: -10...10)
+        let finalOffset = viewportWidth / 2 - CGFloat(targetIndex) * slotStride - slotWidth / 2 + jitter
+        let hitGreen = greenIndices.contains(targetIndex)
+
+        Task { @MainActor in
+            if reduceMotion {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    stripOffset = finalOffset
+                }
+                try? await Task.sleep(for: .milliseconds(400))
+            } else {
+                withAnimation(.timingCurve(0.15, 0.85, 0.25, 1.0, duration: spinDuration)) {
+                    stripOffset = finalOffset
+                }
+                try? await Task.sleep(for: .seconds(spinDuration + 0.3))
+            }
+
+            guard !Task.isCancelled else { return }
+
+            if hitGreen {
+                landed = true
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled else { return }
+                onDismiss()
+            } else {
+                landed = false
+                usedAttempts[currentAttempt] = true
+                try? await Task.sleep(for: .milliseconds(800))
+                guard !Task.isCancelled else { return }
+                currentAttempt += 1
+                isSpinning = false
+            }
+        }
+    }
+}
+
+private struct IndicatorTriangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.closeSubpath()
+        return path
     }
 }
 

--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -366,7 +366,7 @@ private struct CrateOpeningDismissView: View {
     private let slotWidth: CGFloat = 52
     private let slotSpacing: CGFloat = 4
     private let viewportWidth: CGFloat = 420
-    private let spinDuration: TimeInterval = 4.0
+    private let spinDuration: TimeInterval = 7.0
     private let greenSlotOffset = 4
 
     @State private var stripOffset: CGFloat = 0
@@ -391,21 +391,36 @@ private struct CrateOpeningDismissView: View {
         Set((0..<3).map { $0 * slotCount + greenSlotOffset })
     }
 
+    private let headerMessages = [
+        "So you'd rather gamble than stand up",
+        "Bold of you to try again",
+        "Fine. Last spin.",
+    ]
+
+    private let loseMessages = [
+        "Saw that coming",
+        "Genuinely impressive",
+    ]
+
+    private let subtitleMessages = [
+        "Most of these are red. Just saying.",
+        "Still feeling lucky?",
+        "Last chance. No pressure.",
+    ]
+
     private var headerText: String {
         switch landed {
         case nil:
-            return currentAttempt == 0 ? "Try your luck!" : "Try again!"
+            return headerMessages[min(currentAttempt, headerMessages.count - 1)]
         case false:
-            return "Not this time..."
+            return loseMessages[min(currentAttempt, loseMessages.count - 1)]
         case true:
-            return "Lucky!"
+            return "Ugh. Fine, go."
         }
     }
 
     private var subtitleText: String {
-        if currentAttempt == 0 { return "One of these lets you skip..." }
-        let remaining = maxAttempts - currentAttempt
-        return remaining == 1 ? "Last chance..." : "\(remaining) chances left"
+        subtitleMessages[min(currentAttempt, subtitleMessages.count - 1)]
     }
 
     var body: some View {
@@ -425,35 +440,68 @@ private struct CrateOpeningDismissView: View {
                 }
             }
 
-            VStack(spacing: 4) {
+            VStack(spacing: 0) {
                 IndicatorTriangle()
-                    .fill(palette.ink)
-                    .frame(width: 12, height: 8)
+                    .fill(palette.accent)
+                    .frame(width: 10, height: 6)
 
-                HStack(spacing: slotSpacing) {
-                    ForEach(0..<totalSlots, id: \.self) { i in
-                        let isGreen = greenIndices.contains(i)
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(isGreen ? Color.green.opacity(0.8) : Color.red.opacity(0.8))
-                            .frame(width: slotWidth, height: 48)
-                            .overlay(
-                                Text(isGreen ? "Skip" : "\u{2715}")
-                                    .font(BreakTypography.label(size: isGreen ? 13 : 16, weight: .medium))
-                                    .foregroundStyle(.white)
-                            )
+                ZStack {
+                    HStack(spacing: slotSpacing) {
+                        ForEach(0..<totalSlots, id: \.self) { i in
+                            let isGreen = greenIndices.contains(i)
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(isGreen ? palette.accent : Color.red.opacity(0.55))
+                                .frame(width: slotWidth, height: 52)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .strokeBorder(
+                                            isGreen ? palette.accent.opacity(0.3) : Color.red.opacity(0.15),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .overlay(
+                                    Text(isGreen ? "Skip" : "\u{2715}")
+                                        .font(BreakTypography.label(size: isGreen ? 13 : 16, weight: .medium))
+                                        .foregroundStyle(.white)
+                                )
+                        }
                     }
+                    .offset(x: stripOffset)
+                    .frame(width: viewportWidth, height: 64, alignment: .leading)
+
+                    HStack(spacing: 0) {
+                        LinearGradient(
+                            colors: [palette.paper, palette.paper.opacity(0)],
+                            startPoint: .leading, endPoint: .trailing
+                        )
+                        .frame(width: 36)
+                        Spacer()
+                        LinearGradient(
+                            colors: [palette.paper.opacity(0), palette.paper],
+                            startPoint: .leading, endPoint: .trailing
+                        )
+                        .frame(width: 36)
+                    }
+
+                    Rectangle()
+                        .fill(palette.accent)
+                        .frame(width: 2, height: 64)
                 }
-                .offset(x: stripOffset)
-                .frame(width: viewportWidth, height: 60, alignment: .leading)
-                .clipped()
+                .frame(width: viewportWidth, height: 64)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
                 .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(palette.paper.opacity(0.3))
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(palette.paper.opacity(0.4))
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8)
+                    RoundedRectangle(cornerRadius: 10)
                         .strokeBorder(palette.paperEdge, lineWidth: 1)
                 )
+
+                IndicatorTriangle()
+                    .fill(palette.accent)
+                    .frame(width: 10, height: 6)
+                    .rotationEffect(.degrees(180))
             }
 
             Text(subtitleText)
@@ -517,7 +565,7 @@ private struct CrateOpeningDismissView: View {
                 }
                 try? await Task.sleep(for: .milliseconds(400))
             } else {
-                withAnimation(.timingCurve(0.15, 0.85, 0.25, 1.0, duration: spinDuration)) {
+                withAnimation(.timingCurve(0.1, 0.8, 0.2, 1.0, duration: spinDuration)) {
                     stripOffset = finalOffset
                 }
                 try? await Task.sleep(for: .seconds(spinDuration + 0.3))

--- a/StandLockKit/Sources/Locking/LockStateMachine.swift
+++ b/StandLockKit/Sources/Locking/LockStateMachine.swift
@@ -65,8 +65,10 @@ public struct LockStateMachine: Sendable {
             }
 
         case (.active(.gentle, _), .skipRequested):
-            dailySkipCount += 1
-            state = .dismissed(outcome: .skipped)
+            if dailySkipCount < dailySkipLimit {
+                dailySkipCount += 1
+                state = .dismissed(outcome: .skipped)
+            }
 
         case (.active(.firm, _), .phraseTyped(let correct)):
             if correct && dailySkipCount < dailySkipLimit {

--- a/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/AppPreferences.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct AppPreferences: Codable, Sendable, Equatable {
+    public var gentleDailySkipLimit: Int
     public var firmSkipDelay: TimeInterval
     public var firmEscapePhrase: String
     public var firmDailySkipLimit: Int
@@ -21,6 +22,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
     public var resetIntervalOnSkip: Bool
 
     public init(
+        gentleDailySkipLimit: Int = 5,
         firmSkipDelay: TimeInterval = 10,
         firmEscapePhrase: String = "I choose to skip this break",
         firmDailySkipLimit: Int = 5,
@@ -36,6 +38,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
         pauseMediaDuringBreak: Bool = true,
         resetIntervalOnSkip: Bool = true
     ) {
+        self.gentleDailySkipLimit = gentleDailySkipLimit
         self.firmSkipDelay = firmSkipDelay
         self.firmEscapePhrase = firmEscapePhrase
         self.firmDailySkipLimit = firmDailySkipLimit
@@ -53,6 +56,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case gentleDailySkipLimit
         case firmSkipDelay, firmEscapePhrase, firmDailySkipLimit
         case strictEscapeHoldDuration
         case cameraDetection, microphoneDetection
@@ -65,6 +69,7 @@ public struct AppPreferences: Codable, Sendable, Equatable {
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        gentleDailySkipLimit = try c.decodeIfPresent(Int.self, forKey: .gentleDailySkipLimit) ?? 5
         firmSkipDelay = try c.decodeIfPresent(TimeInterval.self, forKey: .firmSkipDelay) ?? 10
         firmEscapePhrase = try c.decodeIfPresent(String.self, forKey: .firmEscapePhrase) ?? "I choose to skip this break"
         firmDailySkipLimit = try c.decodeIfPresent(Int.self, forKey: .firmDailySkipLimit) ?? 5

--- a/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
@@ -13,7 +13,7 @@ public enum DisciplineLevel: String, Codable, Sendable, CaseIterable {
 
     public func dailySkipLimit(preferences: AppPreferences) -> Int? {
         switch self {
-        case .gentle: nil
+        case .gentle: preferences.gentleDailySkipLimit
         case .firm: preferences.firmDailySkipLimit
         case .strict: nil
         }

--- a/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
@@ -36,6 +36,7 @@ extension DisciplineLevel {
                 EnforcementTier(skipDelay: 0, dismissMechanism: .button),
                 EnforcementTier(skipDelay: 5, dismissMechanism: .button),
                 EnforcementTier(skipDelay: 10, dismissMechanism: .findButton(count: 8, attempts: 3)),
+                EnforcementTier(skipDelay: 12, dismissMechanism: .crateOpening(slotCount: 12, maxAttempts: 3)),
                 EnforcementTier(skipDelay: 15, dismissMechanism: .typePhrase(phrase: "skip", requiresConfirmation: false)),
             ])
         case .firm:

--- a/StandLockKit/Sources/StandLockCore/Models/EnforcementPolicy.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/EnforcementPolicy.swift
@@ -4,6 +4,7 @@ public enum DismissMechanism: Sendable, Equatable {
     case button
     case typePhrase(phrase: String, requiresConfirmation: Bool)
     case findButton(count: Int, attempts: Int)
+    case crateOpening(slotCount: Int, maxAttempts: Int)
     case keyCombo(duration: TimeInterval)
 }
 

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -192,15 +192,17 @@ struct ScheduleModelTests {
 
     @Test func enforcementPolicyGentleTiers() {
         let policy = DisciplineLevel.gentle.enforcementPolicy(preferences: AppPreferences())
-        #expect(policy.tiers.count == 4)
+        #expect(policy.tiers.count == 5)
         #expect(policy.tiers[0].dismissMechanism == .button)
         #expect(policy.tiers[0].skipDelay == 0)
         #expect(policy.tiers[1].dismissMechanism == .button)
         #expect(policy.tiers[1].skipDelay == 5)
         #expect(policy.tiers[2].dismissMechanism == .findButton(count: 8, attempts: 3))
         #expect(policy.tiers[2].skipDelay == 10)
-        #expect(policy.tiers[3].dismissMechanism == .typePhrase(phrase: "skip", requiresConfirmation: false))
-        #expect(policy.tiers[3].skipDelay == 15)
+        #expect(policy.tiers[3].dismissMechanism == .crateOpening(slotCount: 12, maxAttempts: 3))
+        #expect(policy.tiers[3].skipDelay == 12)
+        #expect(policy.tiers[4].dismissMechanism == .typePhrase(phrase: "skip", requiresConfirmation: false))
+        #expect(policy.tiers[4].skipDelay == 15)
     }
 
     @Test func enforcementPolicyFirmUsesPreferences() {
@@ -231,7 +233,7 @@ struct ScheduleModelTests {
     @Test func enforcementPolicyTierClampsToRange() {
         let policy = DisciplineLevel.gentle.enforcementPolicy(preferences: AppPreferences())
         let last = policy.tier(at: 99)
-        #expect(last == policy.tiers[3])
+        #expect(last == policy.tiers[4])
         let first = policy.tier(at: -1)
         #expect(first == policy.tiers[0])
     }

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -182,8 +182,8 @@ struct ScheduleModelTests {
     // MARK: - DisciplineLevel
 
     @Test func dailySkipLimitPerDisciplineLevel() {
-        let prefs = AppPreferences(firmDailySkipLimit: 3)
-        #expect(DisciplineLevel.gentle.dailySkipLimit(preferences: prefs) == nil)
+        let prefs = AppPreferences(gentleDailySkipLimit: 4, firmDailySkipLimit: 3)
+        #expect(DisciplineLevel.gentle.dailySkipLimit(preferences: prefs) == 4)
         #expect(DisciplineLevel.firm.dailySkipLimit(preferences: prefs) == 3)
         #expect(DisciplineLevel.strict.dailySkipLimit(preferences: prefs) == nil)
     }


### PR DESCRIPTION
## Summary
- Add crate opening (slot machine) dismiss mechanism as Gentle tier 4 — user spins a strip of red/green slots with escalating win probability across 3 attempts
- Add daily skip limit (5 skips per day) for Gentle discipline level, resetting at midnight
- Redesign crate strip with palette-based colors, edge fade gradients, center indicator line, and CS:GO-style 7-second deceleration curve
- Add escalating snarky messages that match the existing FindButton dismiss tone ("So you'd rather gamble than stand up", "Saw that coming", etc.)

## Test plan
- [ ] Trigger Gentle tier 4 (skip 4 times) and verify crate opening appears
- [ ] Spin and verify 7s animation with smooth deceleration
- [ ] Lose all 3 attempts and verify escalating teasing messages
- [ ] Win a spin and verify dismiss works
- [ ] Verify daily skip limit resets after midnight
- [ ] Verify skip counter persists across app restarts