### PR TITLE
feat: unlock Gentle tier 4 with funny typePhrase escalation

### DIFF
--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -89,7 +89,7 @@ public final class BreakCoordinator: BreakCoordinating {
         guard var event = currentBreak else { return }
         event.outcome = .skipped
         if let scheduleID = currentBreak?.scheduleId {
-            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 3)
+            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 4)
         }
         locker.dismissOverlay()
         statistics.breaksSkipped += 1
@@ -105,7 +105,7 @@ public final class BreakCoordinator: BreakCoordinating {
         guard var event = currentBreak else { return }
         event.outcome = .escaped
         if let scheduleID = currentBreak?.scheduleId {
-            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 3)
+            escalationTiers[scheduleID, default: 0] = min(escalationTiers[scheduleID, default: 0] + 1, 4)
         }
         locker.dismissOverlay()
         statistics.breaksEscaped += 1
@@ -136,7 +136,8 @@ public final class BreakCoordinator: BreakCoordinating {
 
     private func currentTier(for schedule: Schedule) -> Int {
         guard schedule.progressiveEnforcement else { return 0 }
-        return min(escalationTiers[schedule.id, default: 0], 3)
+        let maxTier = schedule.disciplineLevel.enforcementPolicy(preferences: preferences).tiers.count - 1
+        return min(escalationTiers[schedule.id, default: 0], maxTier)
     }
 
     // MARK: - Private

--- a/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/DisciplineLevel.swift
@@ -37,7 +37,7 @@ extension DisciplineLevel {
                 EnforcementTier(skipDelay: 5, dismissMechanism: .button),
                 EnforcementTier(skipDelay: 10, dismissMechanism: .findButton(count: 8, attempts: 3)),
                 EnforcementTier(skipDelay: 12, dismissMechanism: .crateOpening(slotCount: 12, maxAttempts: 3)),
-                EnforcementTier(skipDelay: 15, dismissMechanism: .typePhrase(phrase: "skip", requiresConfirmation: false)),
+                EnforcementTier(skipDelay: 15, dismissMechanism: .typePhrase(phrase: "My legs are decorative", requiresConfirmation: false)),
             ])
         case .firm:
             let phrase = preferences.firmEscapePhrase

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -503,11 +503,16 @@ struct BreakCoordinatorTests {
         try? await Task.sleep(for: .milliseconds(300))
         #expect(locker.lastEscalationTier == 3)
 
-        // Cap at 3
         coordinator.skipActiveBreak()
         scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
         try? await Task.sleep(for: .milliseconds(300))
-        #expect(locker.lastEscalationTier == 3)
+        #expect(locker.lastEscalationTier == 4)
+
+        // Cap at 4 (gentle has 5 tiers, index 0-4)
+        coordinator.skipActiveBreak()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastEscalationTier == 4)
 
         coordinator.stop()
     }

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -201,7 +201,7 @@ struct ScheduleModelTests {
         #expect(policy.tiers[2].skipDelay == 10)
         #expect(policy.tiers[3].dismissMechanism == .crateOpening(slotCount: 12, maxAttempts: 3))
         #expect(policy.tiers[3].skipDelay == 12)
-        #expect(policy.tiers[4].dismissMechanism == .typePhrase(phrase: "skip", requiresConfirmation: false))
+        #expect(policy.tiers[4].dismissMechanism == .typePhrase(phrase: "My legs are decorative", requiresConfirmation: false))
         #expect(policy.tiers[4].skipDelay == 15)
     }
 


### PR DESCRIPTION
## Summary
- Fix escalation tier clamp that prevented Gentle tier 4 (typePhrase) from ever being reached — `currentTier()` was hardcoded to cap at 3 regardless of stored tier
- Replace placeholder phrase `"skip"` with `"My legs are decorative"` for the 5th skip
- Make `currentTier()` derive its max from the actual policy tier count so it works correctly for all discipline levels

## Changes
- `BreakCoordinator.swift`: bump skip/escape tier storage clamp from 3→4, make `currentTier()` dynamic
- `DisciplineLevel.swift`: update Gentle tier 4 phrase
- `StandLockCoreTests.swift`: update assertion to match new phrase

## Test plan
- [ ] Skip 5 times in Gentle mode — should see: button → button → findButton → crateOpening → typePhrase "My legs are decorative"
- [ ] Verify daily skip limit still kicks in correctly
- [ ] Verify Firm and Strict escalation is unaffected