### PR TITLE
Add break statistics dashboard with history tracking

### DIFF
--- a/StandLock.xcodeproj/project.pbxproj
+++ b/StandLock.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		F1A2B3C4D5E6F7081920A1B2 /* MediaController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7081920A1B3 /* MediaController.swift */; };
 		FBB74759FC16BB2E5F728128 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A85E4C082C8E3C5083ABAEB /* OnboardingView.swift */; };
 		FF4C7AAB3CFF56C574A3EAA2 /* BreakPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3B7E68FDF3C989BA50F367 /* BreakPalette.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6071829304A5B6C /* StatisticsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -88,6 +89,7 @@
 		E2E6E6102A1900D1FAB2A856 /* DetectionSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionSettingsView.swift; sourceTree = "<group>"; };
 		E5A68046037D0CAAE70C0F88 /* ActionArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionArea.swift; sourceTree = "<group>"; };
 		FE0E2C708B760F809144B756 /* PermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChecker.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6071829304A5B6C /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				14C3EDA84FE380ED1AF6CE8A /* ScheduleFormView.swift */,
 				512EB234C46341A2816AAE12 /* SettingsView.swift */,
 				303422D10B9C319038D63E32 /* SoftwareUpdate.swift */,
+				B2C3D4E5F6071829304A5B6C /* StatisticsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				B0845F2F14770C95395FBA5F /* ScheduleFormView.swift in Sources */,
 				6AF974084F51158A71D9EA47 /* SettingsView.swift in Sources */,
 				009F1339F2742632532208AA /* SoftwareUpdate.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* StatisticsView.swift in Sources */,
 				2CD0D3C3CF795626E50A5EAA /* StandLockApp.swift in Sources */,
 				D588F2EB46E9B8124422C5EE /* StatsFooter.swift in Sources */,
 				51FC83BD2349C694BF8C11DD /* TimerNumerals.swift in Sources */,

--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -24,7 +24,7 @@ private final class OnboardingWindowCloseDelegate: NSObject, NSWindowDelegate {
 @MainActor
 final class AppCoordinator: ObservableObject {
     enum SettingsTab: Int, Hashable {
-        case general, schedules, detection, permissions, about
+        case general, schedules, detection, permissions, statistics, about
     }
 
     @Published var selectedSettingsTab: SettingsTab = .general
@@ -42,6 +42,7 @@ final class AppCoordinator: ObservableObject {
     @Published var hasCompletedOnboarding: Bool = false
     @Published private(set) var breakProgress: Double = 0
     @Published private(set) var menuBarTimerText: String?
+    @Published var breakHistory: BreakHistory = BreakHistory()
 
     let permissionChecker = PermissionChecker()
 
@@ -112,6 +113,28 @@ final class AppCoordinator: ObservableObject {
             todayStats = decoded
             todayStats.resetWeeklyIfNeeded(currentDate: Date())
         }
+
+        if let data = UserDefaults.standard.data(forKey: "breakHistory"),
+           let decoded = try? JSONDecoder().decode(BreakHistory.self, from: data) {
+            breakHistory = decoded
+        }
+        let cutoff = DailyBreakRecord.dateKey(
+            from: Calendar.current.date(byAdding: .day, value: -400, to: Date())!
+        )
+        breakHistory.pruneOlderThan(cutoff)
+
+        if breakHistory.records.isEmpty && todayStats.breaksCompleted > 0 {
+            let key = DailyBreakRecord.dateKey(from: Date())
+            let record = DailyBreakRecord(
+                dateKey: key,
+                breaksCompleted: todayStats.breaksCompleted,
+                breaksSkipped: todayStats.breaksSkipped,
+                breaksEscaped: todayStats.breaksEscaped,
+                hadActiveSchedule: !schedules.filter(\.isEnabled).isEmpty
+            )
+            breakHistory.upsert(record)
+            saveHistory()
+        }
     }
 
     func saveSchedules() {
@@ -156,6 +179,31 @@ final class AppCoordinator: ObservableObject {
     func saveStatistics() {
         guard let data = try? JSONEncoder().encode(todayStats) else { return }
         UserDefaults.standard.set(data, forKey: "statistics")
+    }
+
+    func saveHistory() {
+        guard let data = try? JSONEncoder().encode(breakHistory) else { return }
+        UserDefaults.standard.set(data, forKey: "breakHistory")
+    }
+
+    private func updateDailyHistory(_ stats: BreakStatistics) {
+        let key = DailyBreakRecord.dateKey(from: Date())
+        let hasActiveSchedule = !schedules.filter(\.isEnabled).isEmpty
+        var record = breakHistory.record(for: key)
+            ?? DailyBreakRecord(dateKey: key, hadActiveSchedule: hasActiveSchedule)
+        record.breaksCompleted = stats.breaksCompleted
+        record.breaksSkipped = stats.breaksSkipped
+        record.breaksEscaped = stats.breaksEscaped
+        record.hadActiveSchedule = hasActiveSchedule
+
+        let enabledSchedules = schedules.filter(\.isEnabled)
+        let avgDuration = enabledSchedules.isEmpty
+            ? 300.0
+            : enabledSchedules.map(\.breakDuration).reduce(0, +) / Double(enabledSchedules.count)
+        record.totalBreakDuration = Double(stats.breaksCompleted) * avgDuration
+
+        breakHistory.upsert(record)
+        saveHistory()
     }
 
     // MARK: - Coordinator Lifecycle
@@ -258,6 +306,7 @@ final class AppCoordinator: ObservableObject {
         case .statisticsUpdated(let stats):
             todayStats = stats
             saveStatistics()
+            updateDailyHistory(stats)
         }
     }
 

--- a/StandLock/Views/Settings/SettingsView.swift
+++ b/StandLock/Views/Settings/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
             tabContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(width: 520, height: 480)
+        .frame(width: 520, height: selectedTab == .statistics ? 580 : 480)
     }
 
     @ViewBuilder
@@ -22,6 +22,7 @@ struct SettingsView: View {
         case .schedules: ScheduleEditorView()
         case .detection: DetectionSettingsView()
         case .permissions: PermissionsView()
+        case .statistics: StatisticsView()
         case .about: AboutView(updater: updater)
         }
     }
@@ -35,6 +36,7 @@ private struct SettingsTabBar: View {
         (.schedules, "Schedules", "calendar.badge.clock"),
         (.detection, "Detection", "eye"),
         (.permissions, "Permissions", "lock.shield"),
+        (.statistics, "Statistics", "chart.bar.xaxis"),
         (.about, "About", "info.circle"),
     ]
 

--- a/StandLock/Views/Settings/StatisticsView.swift
+++ b/StandLock/Views/Settings/StatisticsView.swift
@@ -1,0 +1,452 @@
+import SwiftUI
+import StandLockCore
+
+struct StatisticsView: View {
+    @EnvironmentObject private var coordinator: AppCoordinator
+    @State private var selectedPeriod: StatsPeriod = .month
+    @State private var cachedHeatmap: HeatmapData?
+    @State private var cachedStats: AggregateStats = .empty
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                headerRow
+                metricsGrid
+                Group {
+                    switch selectedPeriod {
+                    case .today:
+                        EmptyView()
+                    case .week:
+                        WeekCardsView(history: coordinator.breakHistory,
+                                      activeDays: cachedStats.activeDays)
+                    case .month:
+                        MonthCalendarView(history: coordinator.breakHistory,
+                                          activeDays: cachedStats.activeDays)
+                    case .year:
+                        if let heatmap = cachedHeatmap {
+                            YearHeatmapView(data: heatmap,
+                                            activeDays: cachedStats.activeDays)
+                        }
+                    }
+                }
+                .animation(.easeInOut(duration: 0.25), value: selectedPeriod)
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear { rebuildCache() }
+        .onChange(of: coordinator.breakHistory.records.count) { _ in rebuildCache() }
+        .onChange(of: selectedPeriod) { _ in
+            cachedStats = coordinator.breakHistory.aggregateStats(for: selectedPeriod)
+        }
+    }
+
+    private func rebuildCache() {
+        cachedHeatmap = HeatmapData(history: coordinator.breakHistory, referenceDate: Date())
+        cachedStats = coordinator.breakHistory.aggregateStats(for: selectedPeriod)
+    }
+
+    private var headerRow: some View {
+        HStack {
+            Text("Break Statistics")
+                .font(.headline)
+            Spacer()
+            Picker("Period", selection: $selectedPeriod) {
+                ForEach(StatsPeriod.allCases) { period in
+                    Text(period.rawValue).tag(period)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 240)
+        }
+    }
+
+    private var metricsGrid: some View {
+        let s = cachedStats
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 3), spacing: 12) {
+            StatCard(icon: "checkmark.circle", label: "Completed", value: "\(s.totalCompleted)", color: .green)
+            StatCard(icon: "forward.end", label: "Skipped", value: "\(s.totalSkipped)", color: .orange)
+            StatCard(icon: "chart.bar", label: "Completion", value: "\(Int(s.completionRate * 100))%", color: .blue)
+            StatCard(icon: "flame", label: "Streak", value: "\(s.currentStreak)d", color: .red)
+            StatCard(icon: "trophy", label: "Best Streak", value: "\(s.bestStreak)d", color: .purple)
+            StatCard(icon: "clock", label: "Break Time", value: formattedTime(s.totalBreakTime), color: .cyan)
+        }
+    }
+
+    private func formattedTime(_ seconds: TimeInterval) -> String {
+        let hours = Int(seconds) / 3600
+        let minutes = (Int(seconds) % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+}
+
+// MARK: - Heatmap Color
+
+private func heatmapColor(count: Int, maxCount: Int) -> Color {
+    guard maxCount > 0, count > 0 else {
+        return Color(.systemGray).opacity(0.15)
+    }
+    let ratio = Double(count) / Double(maxCount)
+    switch ratio {
+    case ..<0.25: return .green.opacity(0.3)
+    case ..<0.50: return .green.opacity(0.5)
+    case ..<0.75: return .green.opacity(0.7)
+    default:      return .green.opacity(1.0)
+    }
+}
+
+// MARK: - Year Heatmap View
+
+private struct YearHeatmapView: View {
+    let data: HeatmapData
+    let activeDays: Int
+
+    private let cellSize: CGFloat = 11
+    private let cellSpacing: CGFloat = 3
+    private let labelWidth: CGFloat = 28
+
+    private var gridWidth: CGFloat {
+        CGFloat(data.weeks.count) * (cellSize + cellSpacing) - cellSpacing
+    }
+
+    private var gridHeight: CGFloat {
+        7 * (cellSize + cellSpacing) - cellSpacing
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Break Activity").font(.subheadline).fontWeight(.semibold)
+                Spacer()
+                Text("\(activeDays) days with breaks")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        monthLabelsRow
+                        HStack(alignment: .top, spacing: 0) {
+                            dayLabelsColumn
+                            canvas
+                            Color.clear.frame(width: 1, height: 1).id("heatmap-end")
+                        }
+                    }
+                }
+                .onAppear {
+                    proxy.scrollTo("heatmap-end", anchor: .trailing)
+                }
+            }
+
+            legendRow
+        }
+        .padding(16)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
+        .transition(.opacity.combined(with: .scale(scale: 0.98)))
+    }
+
+    private var canvas: some View {
+        Canvas { context, _ in
+            for col in 0..<data.weeks.count {
+                for row in 0..<7 {
+                    let x = CGFloat(col) * (cellSize + cellSpacing)
+                    let y = CGFloat(row) * (cellSize + cellSpacing)
+                    let rect = CGRect(x: x, y: y, width: cellSize, height: cellSize)
+                    let path = Path(roundedRect: rect, cornerRadius: 2)
+
+                    if let day = data.weeks[col][row] {
+                        let color = heatmapColor(count: day.breakCount, maxCount: data.maxCount)
+                        context.fill(path, with: .color(color))
+                    }
+                }
+            }
+        }
+        .frame(width: gridWidth, height: gridHeight)
+    }
+
+    private var monthLabelsRow: some View {
+        HStack(spacing: 0) {
+            Color.clear.frame(width: labelWidth, height: 12)
+            ForEach(0..<data.weeks.count, id: \.self) { col in
+                if let label = data.monthLabels[col] {
+                    Text(label)
+                        .font(.caption2)
+                        .fixedSize()
+                        .foregroundStyle(.secondary)
+                        .frame(width: cellSize + cellSpacing, alignment: .leading)
+                } else {
+                    Color.clear.frame(width: cellSize + cellSpacing, height: 12)
+                }
+            }
+        }
+    }
+
+    private var dayLabelsColumn: some View {
+        VStack(spacing: cellSpacing) {
+            ForEach(0..<7, id: \.self) { row in
+                if row == 0 || row == 2 || row == 4 {
+                    Text(["Mon", "", "Wed", "", "Fri", "", ""][row])
+                        .font(.system(size: 9)).foregroundStyle(.secondary)
+                        .frame(width: labelWidth, height: cellSize, alignment: .trailing)
+                } else {
+                    Color.clear.frame(width: labelWidth, height: cellSize)
+                }
+            }
+        }
+    }
+
+    private var legendRow: some View {
+        HStack(spacing: 3) {
+            Spacer()
+            Text("Less").font(.system(size: 10)).foregroundStyle(.secondary)
+            ForEach([0.15, 0.3, 0.5, 0.7, 1.0], id: \.self) { opacity in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(opacity == 0.15 ? Color(.systemGray).opacity(0.15) : .green.opacity(opacity))
+                    .frame(width: cellSize, height: cellSize)
+            }
+            Text("More").font(.system(size: 10)).foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Month Calendar View
+
+private struct MonthCalendarView: View {
+    let history: BreakHistory
+    let activeDays: Int
+
+    private static let dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+
+    var body: some View {
+        let calendar = Calendar.current
+        let now = Date()
+        let components = calendar.dateComponents([.year, .month], from: now)
+        let monthStart = calendar.date(from: components)!
+        let daysInMonth = calendar.range(of: .day, in: .month, for: monthStart)!.count
+        let firstWeekday = calendar.component(.weekday, from: monthStart)
+        let offset = (firstWeekday + 5) % 7
+        let todayKey = DailyBreakRecord.dateKey(from: now)
+        let maxCount = maxBreakCount(calendar: calendar, monthStart: monthStart, daysInMonth: daysInMonth)
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(monthYearString(from: now)).font(.subheadline).fontWeight(.semibold)
+                Spacer()
+                Text("\(activeDays) days with breaks")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            LazyVGrid(columns: columns, spacing: 4) {
+                ForEach(Self.dayNames, id: \.self) { name in
+                    Text(name)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                }
+
+                ForEach(0..<offset, id: \.self) { _ in
+                    Color.clear.frame(height: 44)
+                }
+
+                ForEach(1...daysInMonth, id: \.self) { day in
+                    let date = calendar.date(byAdding: .day, value: day - 1, to: monthStart)!
+                    let key = DailyBreakRecord.dateKey(from: date)
+                    let count = history.record(for: key)?.breaksCompleted ?? 0
+                    let isToday = key == todayKey
+
+                    VStack(spacing: 2) {
+                        Text("\(day)").font(.caption)
+                        if count > 0 {
+                            Text("\(count)").font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(heatmapColor(count: count, maxCount: maxCount))
+                    )
+                    .overlay {
+                        if isToday {
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.accentColor, lineWidth: 1.5)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
+        .transition(.opacity.combined(with: .scale(scale: 0.98)))
+    }
+
+    private func maxBreakCount(calendar: Calendar, monthStart: Date, daysInMonth: Int) -> Int {
+        var result = 0
+        for day in 0..<daysInMonth {
+            let date = calendar.date(byAdding: .day, value: day, to: monthStart)!
+            let count = history.record(for: DailyBreakRecord.dateKey(from: date))?.breaksCompleted ?? 0
+            if count > result { result = count }
+        }
+        return result
+    }
+
+    private func monthYearString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Week Calendar View
+
+private struct WeekCardsView: View {
+    let history: BreakHistory
+    let activeDays: Int
+
+    private static let dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+
+    var body: some View {
+        let calendar = Calendar.current
+        let now = Date()
+        let todayWeekday = calendar.component(.weekday, from: now)
+        let daysFromMonday = (todayWeekday - 2 + 7) % 7
+        let monday = calendar.date(byAdding: .day, value: -daysFromMonday,
+                                   to: calendar.startOfDay(for: now))!
+        let todayKey = DailyBreakRecord.dateKey(from: now)
+
+        let weekDates: [(day: Int, key: String, count: Int)] = (0..<7).map { i in
+            let date = calendar.date(byAdding: .day, value: i, to: monday)!
+            let key = DailyBreakRecord.dateKey(from: date)
+            let count = history.record(for: key)?.breaksCompleted ?? 0
+            return (day: calendar.component(.day, from: date), key: key, count: count)
+        }
+        let maxCount = weekDates.map(\.count).max() ?? 0
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("This Week").font(.subheadline).fontWeight(.semibold)
+                Spacer()
+                Text("\(activeDays) days with breaks")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+
+            LazyVGrid(columns: columns, spacing: 4) {
+                ForEach(Self.dayNames, id: \.self) { name in
+                    Text(name)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                }
+
+                ForEach(0..<7, id: \.self) { i in
+                    let entry = weekDates[i]
+                    let isToday = entry.key == todayKey
+
+                    VStack(spacing: 2) {
+                        Text("\(entry.day)").font(.caption)
+                        if entry.count > 0 {
+                            Text("\(entry.count)").font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(heatmapColor(count: entry.count, maxCount: maxCount))
+                    )
+                    .overlay {
+                        if isToday {
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.accentColor, lineWidth: 1.5)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 10))
+        .transition(.opacity.combined(with: .scale(scale: 0.98)))
+    }
+}
+
+// MARK: - Stat Card
+
+private struct StatCard: View {
+    let icon: String
+    let label: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 4) {
+                Image(systemName: icon).font(.caption2)
+                Text(label).font(.caption).foregroundStyle(.secondary)
+            }
+            Text(value)
+                .font(.title2).fontWeight(.bold)
+                .foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+// MARK: - Heatmap Data
+
+private struct HeatmapData {
+    struct HeatmapDay {
+        let dateKey: String
+        let breakCount: Int
+    }
+
+    let weeks: [[HeatmapDay?]]
+    let monthLabels: [Int: String]
+    let activeDaysCount: Int
+    let maxCount: Int
+
+    init(history: BreakHistory, referenceDate: Date) {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 2
+
+        var weeksArray: [[HeatmapDay?]] = Array(repeating: Array(repeating: nil, count: 7), count: 53)
+        var labels: [Int: String] = [:]
+        var activeCount = 0
+        var maxBreaks = 0
+        var lastMonth = -1
+        var lastLabelCol = -10
+
+        for dayOffset in 0..<365 {
+            guard let day = calendar.date(byAdding: .day, value: -(364 - dayOffset), to: referenceDate) else { continue }
+            let key = DailyBreakRecord.dateKey(from: day)
+            let weekday = calendar.component(.weekday, from: day)
+            let row = (weekday + 5) % 7
+            let col = dayOffset / 7
+
+            let breakCount = history.record(for: key)?.breaksCompleted ?? 0
+            if breakCount > 0 { activeCount += 1 }
+            if breakCount > maxBreaks { maxBreaks = breakCount }
+
+            weeksArray[col][row] = HeatmapDay(dateKey: key, breakCount: breakCount)
+
+            let month = calendar.component(.month, from: day)
+            if month != lastMonth {
+                lastMonth = month
+                if col - lastLabelCol >= 3 {
+                    labels[col] = calendar.shortMonthSymbols[month - 1]
+                    lastLabelCol = col
+                }
+            }
+        }
+
+        weeks = weeksArray
+        monthLabels = labels
+        activeDaysCount = activeCount
+        self.maxCount = maxBreaks
+    }
+}

--- a/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+public enum StatsPeriod: String, CaseIterable, Identifiable, Sendable {
+    case today = "Today"
+    case week = "Week"
+    case month = "Month"
+    case year = "Year"
+
+    public var id: Self { self }
+}
+
+public struct AggregateStats: Equatable, Sendable {
+    public let totalCompleted: Int
+    public let totalSkipped: Int
+    public let totalEscaped: Int
+    public let completionRate: Double
+    public let currentStreak: Int
+    public let bestStreak: Int
+    public let totalBreakTime: TimeInterval
+    public let activeDays: Int
+
+    public static let empty = AggregateStats(
+        totalCompleted: 0, totalSkipped: 0, totalEscaped: 0,
+        completionRate: 0, currentStreak: 0, bestStreak: 0,
+        totalBreakTime: 0, activeDays: 0
+    )
+}
+
+public struct BreakHistory: Codable, Sendable {
+    public var records: [String: DailyBreakRecord]
+    public var bestStreak: Int
+
+    public init() {
+        records = [:]
+        bestStreak = 0
+    }
+
+    public func record(for dateKey: String) -> DailyBreakRecord? {
+        records[dateKey]
+    }
+
+    public func records(in range: ClosedRange<String>) -> [DailyBreakRecord] {
+        records.values
+            .filter { range.contains($0.dateKey) }
+            .sorted { $0.dateKey < $1.dateKey }
+    }
+
+    public mutating func upsert(_ record: DailyBreakRecord) {
+        records[record.dateKey] = record
+        let streak = currentStreak(referenceDate: DailyBreakRecord.date(from: record.dateKey) ?? Date())
+        if streak > bestStreak {
+            bestStreak = streak
+        }
+    }
+
+    public mutating func pruneOlderThan(_ dateKey: String) {
+        records = records.filter { $0.key >= dateKey }
+    }
+
+    // MARK: - Streak
+
+    public func currentStreak(referenceDate: Date = Date()) -> Int {
+        let calendar = Calendar.current
+        var streak = 0
+        var dayOffset = 0
+
+        while true {
+            guard let day = calendar.date(byAdding: .day, value: -dayOffset, to: referenceDate) else { break }
+            let key = DailyBreakRecord.dateKey(from: day)
+
+            if let record = records[key] {
+                if !record.hadActiveSchedule {
+                    dayOffset += 1
+                    continue
+                }
+                if record.breaksCompleted >= 1 {
+                    streak += 1
+                    dayOffset += 1
+                    continue
+                }
+                break
+            } else {
+                if dayOffset == 0 {
+                    dayOffset += 1
+                    continue
+                }
+                break
+            }
+        }
+        return streak
+    }
+
+    // MARK: - Aggregation
+
+    public func aggregateStats(for period: StatsPeriod, referenceDate: Date = Date()) -> AggregateStats {
+        let calendar = Calendar.current
+        let daysBack: Int
+        switch period {
+        case .today: daysBack = 0
+        case .week: daysBack = 6
+        case .month: daysBack = 29
+        case .year: daysBack = 364
+        }
+
+        let startDate = calendar.date(byAdding: .day, value: -daysBack, to: referenceDate)!
+        let startKey = DailyBreakRecord.dateKey(from: startDate)
+        let endKey = DailyBreakRecord.dateKey(from: referenceDate)
+        let filtered = records(in: startKey...endKey)
+
+        var totalCompleted = 0
+        var totalSkipped = 0
+        var totalEscaped = 0
+        var totalBreakTime: TimeInterval = 0
+        var activeDays = 0
+
+        for record in filtered {
+            totalCompleted += record.breaksCompleted
+            totalSkipped += record.breaksSkipped
+            totalEscaped += record.breaksEscaped
+            totalBreakTime += record.totalBreakDuration
+            if record.totalBreaks > 0 { activeDays += 1 }
+        }
+
+        let total = totalCompleted + totalSkipped + totalEscaped
+        let completionRate = total > 0 ? Double(totalCompleted) / Double(total) : 0
+
+        let streak = currentStreak(referenceDate: referenceDate)
+
+        return AggregateStats(
+            totalCompleted: totalCompleted,
+            totalSkipped: totalSkipped,
+            totalEscaped: totalEscaped,
+            completionRate: completionRate,
+            currentStreak: streak,
+            bestStreak: bestStreak,
+            totalBreakTime: totalBreakTime,
+            activeDays: activeDays
+        )
+    }
+}

--- a/StandLockKit/Sources/StandLockCore/Models/DailyBreakRecord.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/DailyBreakRecord.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct DailyBreakRecord: Codable, Sendable, Identifiable, Equatable {
+    public var id: String { dateKey }
+    public let dateKey: String
+    public var breaksCompleted: Int
+    public var breaksSkipped: Int
+    public var breaksEscaped: Int
+    public var totalBreakDuration: TimeInterval
+    public var hadActiveSchedule: Bool
+
+    public init(
+        dateKey: String,
+        breaksCompleted: Int = 0,
+        breaksSkipped: Int = 0,
+        breaksEscaped: Int = 0,
+        totalBreakDuration: TimeInterval = 0,
+        hadActiveSchedule: Bool = true
+    ) {
+        self.dateKey = dateKey
+        self.breaksCompleted = breaksCompleted
+        self.breaksSkipped = breaksSkipped
+        self.breaksEscaped = breaksEscaped
+        self.totalBreakDuration = totalBreakDuration
+        self.hadActiveSchedule = hadActiveSchedule
+    }
+
+    public var totalBreaks: Int { breaksCompleted + breaksSkipped + breaksEscaped }
+
+    private static let keyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    public static func dateKey(from date: Date) -> String {
+        keyFormatter.string(from: date)
+    }
+
+    public static func date(from dateKey: String) -> Date? {
+        keyFormatter.date(from: dateKey)
+    }
+}

--- a/StandLockKit/Tests/StandLockCoreTests/BreakHistoryTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/BreakHistoryTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+@testable import StandLockCore
+
+@Suite("BreakHistory Tests")
+struct BreakHistoryTests {
+
+    private func makeRecord(
+        _ dateKey: String,
+        completed: Int = 0,
+        skipped: Int = 0,
+        escaped: Int = 0,
+        duration: TimeInterval = 0,
+        active: Bool = true
+    ) -> DailyBreakRecord {
+        DailyBreakRecord(
+            dateKey: dateKey,
+            breaksCompleted: completed,
+            breaksSkipped: skipped,
+            breaksEscaped: escaped,
+            totalBreakDuration: duration,
+            hadActiveSchedule: active
+        )
+    }
+
+    private func date(_ key: String) -> Date {
+        DailyBreakRecord.date(from: key)!
+    }
+
+    // MARK: - Storage
+
+    @Test func upsertCreatesNewRecord() {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2026-06-01", completed: 3))
+        #expect(history.record(for: "2026-06-01")?.breaksCompleted == 3)
+    }
+
+    @Test func upsertUpdatesExistingRecord() {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2026-06-01", completed: 2))
+        history.upsert(makeRecord("2026-06-01", completed: 5))
+        #expect(history.record(for: "2026-06-01")?.breaksCompleted == 5)
+        #expect(history.records.count == 1)
+    }
+
+    @Test func recordsInRangeFiltersCorrectly() {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2026-05-28", completed: 1))
+        history.upsert(makeRecord("2026-05-29", completed: 2))
+        history.upsert(makeRecord("2026-05-30", completed: 3))
+        history.upsert(makeRecord("2026-06-01", completed: 4))
+
+        let filtered = history.records(in: "2026-05-29"..."2026-05-30")
+        #expect(filtered.count == 2)
+        #expect(filtered[0].dateKey == "2026-05-29")
+        #expect(filtered[1].dateKey == "2026-05-30")
+    }
+
+    @Test func pruneRemovesOldRecords() {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2025-01-01", completed: 1))
+        history.upsert(makeRecord("2026-05-30", completed: 2))
+        history.upsert(makeRecord("2026-06-01", completed: 3))
+
+        history.pruneOlderThan("2026-05-01")
+        #expect(history.records.count == 2)
+        #expect(history.record(for: "2025-01-01") == nil)
+    }
+
+    @Test func jsonRoundTrip() throws {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2026-06-01", completed: 3, skipped: 1, duration: 300))
+
+        let data = try JSONEncoder().encode(history)
+        let decoded = try JSONDecoder().decode(BreakHistory.self, from: data)
+
+        #expect(decoded.records.count == 1)
+        let record = decoded.record(for: "2026-06-01")!
+        #expect(record.breaksCompleted == 3)
+        #expect(record.breaksSkipped == 1)
+        #expect(record.totalBreakDuration == 300)
+    }
+
+    // MARK: - Aggregation
+
+    @Test func aggregateTodayReturnsOnlyTodayStats() {
+        var history = BreakHistory()
+        let todayKey = DailyBreakRecord.dateKey(from: Date())
+        history.upsert(makeRecord(todayKey, completed: 4, skipped: 1))
+        history.upsert(makeRecord("2020-01-01", completed: 10))
+
+        let stats = history.aggregateStats(for: .today)
+        #expect(stats.totalCompleted == 4)
+        #expect(stats.totalSkipped == 1)
+    }
+
+    @Test func aggregateWeekSumsLast7Days() {
+        var history = BreakHistory()
+        let ref = date("2026-06-01")
+        let calendar = Calendar.current
+
+        for offset in 0..<7 {
+            let day = calendar.date(byAdding: .day, value: -offset, to: ref)!
+            let key = DailyBreakRecord.dateKey(from: day)
+            history.upsert(makeRecord(key, completed: 2))
+        }
+        let outside = calendar.date(byAdding: .day, value: -7, to: ref)!
+        history.upsert(makeRecord(DailyBreakRecord.dateKey(from: outside), completed: 100))
+
+        let stats = history.aggregateStats(for: .week, referenceDate: ref)
+        #expect(stats.totalCompleted == 14)
+    }
+
+    @Test func aggregateYearSums365Days() {
+        var history = BreakHistory()
+        let ref = date("2026-06-01")
+        let calendar = Calendar.current
+
+        for offset in 0..<365 {
+            let day = calendar.date(byAdding: .day, value: -offset, to: ref)!
+            let key = DailyBreakRecord.dateKey(from: day)
+            history.upsert(makeRecord(key, completed: 1))
+        }
+
+        let stats = history.aggregateStats(for: .year, referenceDate: ref)
+        #expect(stats.totalCompleted == 365)
+        #expect(stats.activeDays == 365)
+    }
+
+    @Test func completionRateCalculation() {
+        var history = BreakHistory()
+        let ref = date("2026-06-01")
+        history.upsert(makeRecord("2026-06-01", completed: 3, skipped: 1, escaped: 1))
+
+        let stats = history.aggregateStats(for: .today, referenceDate: ref)
+        #expect(stats.completionRate == 3.0 / 5.0)
+    }
+
+    @Test func completionRateZeroWhenNoBreaks() {
+        let history = BreakHistory()
+        let stats = history.aggregateStats(for: .today)
+        #expect(stats.completionRate == 0)
+    }
+
+    // MARK: - Streak
+
+    @Test func currentStreakCountsConsecutiveDays() {
+        var history = BreakHistory()
+        let ref = date("2026-06-03")
+        history.upsert(makeRecord("2026-06-03", completed: 2))
+        history.upsert(makeRecord("2026-06-02", completed: 1))
+        history.upsert(makeRecord("2026-06-01", completed: 3))
+
+        #expect(history.currentStreak(referenceDate: ref) == 3)
+    }
+
+    @Test func streakSkipsInactiveDays() {
+        var history = BreakHistory()
+        let ref = date("2026-06-03")
+        history.upsert(makeRecord("2026-06-03", completed: 1))
+        history.upsert(makeRecord("2026-06-02", completed: 0, active: false))
+        history.upsert(makeRecord("2026-06-01", completed: 2))
+
+        #expect(history.currentStreak(referenceDate: ref) == 2)
+    }
+
+    @Test func streakBreaksOnZeroCompletedActiveDay() {
+        var history = BreakHistory()
+        let ref = date("2026-06-03")
+        history.upsert(makeRecord("2026-06-03", completed: 1))
+        history.upsert(makeRecord("2026-06-02", completed: 0, active: true))
+        history.upsert(makeRecord("2026-06-01", completed: 5))
+
+        #expect(history.currentStreak(referenceDate: ref) == 1)
+    }
+
+    @Test func bestStreakUpdatesOnUpsert() {
+        var history = BreakHistory()
+        history.upsert(makeRecord("2026-06-01", completed: 1))
+        history.upsert(makeRecord("2026-06-02", completed: 1))
+        history.upsert(makeRecord("2026-06-03", completed: 1))
+        #expect(history.bestStreak == 3)
+
+        history.upsert(makeRecord("2026-06-04", completed: 0))
+        #expect(history.bestStreak == 3)
+    }
+
+    @Test func streakHandlesYearBoundary() {
+        var history = BreakHistory()
+        let ref = date("2026-01-02")
+        history.upsert(makeRecord("2026-01-02", completed: 1))
+        history.upsert(makeRecord("2026-01-01", completed: 1))
+        history.upsert(makeRecord("2025-12-31", completed: 1))
+        history.upsert(makeRecord("2025-12-30", completed: 1))
+
+        #expect(history.currentStreak(referenceDate: ref) == 4)
+    }
+
+    // MARK: - DailyBreakRecord
+
+    @Test func dateKeyRoundTrip() {
+        let ref = date("2026-06-01")
+        let key = DailyBreakRecord.dateKey(from: ref)
+        #expect(key == "2026-06-01")
+        let parsed = DailyBreakRecord.date(from: key)
+        #expect(parsed != nil)
+        #expect(DailyBreakRecord.dateKey(from: parsed!) == "2026-06-01")
+    }
+
+    @Test func recordIdentifiable() {
+        let record = makeRecord("2026-06-01", completed: 3)
+        #expect(record.id == "2026-06-01")
+    }
+
+    @Test func recordTotalBreaks() {
+        let record = makeRecord("2026-06-01", completed: 3, skipped: 2, escaped: 1)
+        #expect(record.totalBreaks == 6)
+    }
+}


### PR DESCRIPTION
## Summary

Add a Statistics tab to Settings that tracks daily break activity and displays it across four time periods (Today, Week, Month, Year). Break history is persisted to UserDefaults and pruned to 400 days. The dashboard includes a GitHub-style contribution heatmap for yearly view, calendar grid for monthly view, and week cards for weekly view.

- **New file:** `StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift` -- history storage, streak calculation, period-based aggregation
- **New file:** `StandLockKit/Sources/StandLockCore/Models/DailyBreakRecord.swift` -- per-day break data model with date key formatting
- **New file:** `StandLock/Views/Settings/StatisticsView.swift` -- dashboard UI with period picker, metrics grid, and three visualization types (heatmap, calendar, week cards)
- **Modified:** `AppCoordinator.swift` -- persists break history, syncs daily records on stats updates, seeds from existing stats on first launch
- **Modified:** `SettingsView.swift` -- adds Statistics tab, adjusts window height for statistics content

### How it works

1. Each time `statisticsUpdated` fires, `AppCoordinator` upserts the current day's `DailyBreakRecord` with completed/skipped/escaped counts and estimated break duration.
2. On launch, existing `todayStats` are migrated into history if no records exist yet.
3. Records older than 400 days are pruned on each launch.
4. `StatisticsView` reads `breakHistory` from the coordinator and computes `AggregateStats` (totals, completion rate, streaks) per selected period.
5. Streak logic skips days without an active schedule and breaks on zero-completion active days.

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Storage | UserDefaults | Consistent with existing stats/schedule storage; no CoreData overhead for simple key-value records |
| Retention | 400 days | Covers full year heatmap with buffer; keeps storage bounded |
| Streak skip logic | Skip inactive-schedule days | Users shouldn't lose streaks on weekends/holidays without schedules |
| Canvas for heatmap | SwiftUI Canvas | 365 cells render faster than 365 SwiftUI views; smooth scrolling |

## Test plan

- [ ] Verify upsert, range query, prune, and JSON round-trip in `BreakHistoryTests`
- [ ] Verify streak counts consecutive days, skips inactive days, breaks on zero-completion
- [ ] Verify best streak updates correctly on upsert
- [ ] Open Statistics tab and cycle through Today/Week/Month/Year periods
- [ ] Confirm heatmap scrolls to current date on appear
- [ ] Confirm today cell is highlighted in month and week views