### PR TITLE
fix: follow-up defects around the statistics panel

### DIFF
--- a/StandLock/AppState/AppCoordinator.swift
+++ b/StandLock/AppState/AppCoordinator.swift
@@ -124,7 +124,9 @@ final class AppCoordinator: ObservableObject {
         let cutoff = DailyBreakRecord.dateKey(
             from: Calendar.current.date(byAdding: .day, value: -400, to: Date())!
         )
-        breakHistory.pruneOlderThan(cutoff)
+        if breakHistory.pruneOlderThan(cutoff) {
+            saveHistory()
+        }
 
         // Back-fills today's record for users upgrading from before break history existed. Must
         // stay below the daily reset above, otherwise stale multi-day totals land on today.

--- a/StandLock/Views/BreakScreen/ActionArea.swift
+++ b/StandLock/Views/BreakScreen/ActionArea.swift
@@ -555,7 +555,9 @@ private struct CrateOpeningDismissView: View {
     }
 
     private func spin() {
-        guard !isSpinning else { return }
+        // `usedAttempts` is sized to `maxAttempts`; without this bound a losing spin past the
+        // last attempt would write out of range.
+        guard !isSpinning, currentAttempt < maxAttempts else { return }
         isSpinning = true
         landed = nil
 

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -123,16 +123,18 @@ struct ScheduleFormView: View {
                 .buttonStyle(.plain)
             }
 
-            ForEach(windows.indices, id: \.self) { index in
+            // Bound by identity, not index: removing a row while indices are the identity leaves
+            // SwiftUI holding a stale index and the `$windows[index]` bindings read out of range.
+            ForEach($windows) { $window in
                 HStack(spacing: 8) {
-                    timePicker("Start", hour: $windows[index].startHour, minute: $windows[index].startMinute)
+                    timePicker("Start", hour: $window.startHour, minute: $window.startMinute)
                     Text("to")
                         .foregroundStyle(.secondary)
-                    timePicker("End", hour: $windows[index].endHour, minute: $windows[index].endMinute)
+                    timePicker("End", hour: $window.endHour, minute: $window.endMinute)
 
                     if windows.count > 1 {
                         Button {
-                            windows.remove(at: index)
+                            windows.removeAll { $0.id == window.id }
                         } label: {
                             Image(systemName: "minus.circle")
                                 .foregroundStyle(.red)

--- a/StandLock/Views/Settings/StatisticsView.swift
+++ b/StandLock/Views/Settings/StatisticsView.swift
@@ -36,14 +36,35 @@ struct StatisticsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { rebuildCache() }
         .onChange(of: coordinator.breakHistory.revision) { _ in rebuildCache() }
-        .onChange(of: selectedPeriod) { _ in
-            cachedStats = coordinator.breakHistory.aggregateStats(for: selectedPeriod)
+        .onChange(of: selectedPeriod) { _ in rebuildCache() }
+        .task { await rebuildAtDayBoundary() }
+    }
+
+    /// Both caches are windowed on "now", so they go stale if the panel stays open across
+    /// midnight -- nothing else invalidates them until the next break is recorded.
+    private func rebuildAtDayBoundary() async {
+        let calendar = Calendar.current
+        let midnight = DateComponents(hour: 0, minute: 0, second: 0)
+
+        while !Task.isCancelled {
+            let now = Date()
+            guard let nextDay = calendar.nextDate(after: now, matching: midnight,
+                                                  matchingPolicy: .nextTime) else { return }
+            try? await Task.sleep(for: .seconds(nextDay.timeIntervalSince(now) + 1))
+            guard !Task.isCancelled else { return }
+            rebuildCache()
         }
     }
 
     private func rebuildCache() {
-        cachedHeatmap = HeatmapData(history: coordinator.breakHistory, referenceDate: Date())
-        cachedStats = coordinator.breakHistory.aggregateStats(for: selectedPeriod)
+        let now = Date()
+        // Only the year tab renders the heatmap and building it walks 365 days. The previous
+        // one is left in place rather than cleared so returning to the tab has nothing to
+        // re-render from empty.
+        if selectedPeriod == .year {
+            cachedHeatmap = HeatmapData(history: coordinator.breakHistory, referenceDate: now)
+        }
+        cachedStats = coordinator.breakHistory.aggregateStats(for: selectedPeriod, referenceDate: now)
     }
 
     private var headerRow: some View {

--- a/StandLock/Views/Settings/StatisticsView.swift
+++ b/StandLock/Views/Settings/StatisticsView.swift
@@ -184,6 +184,9 @@ private struct YearHeatmapView: View {
                     if let day = data.weeks[col][row] {
                         let color = heatmapColor(count: day.breakCount, maxCount: data.maxCount)
                         context.fill(path, with: .color(color))
+                        if day.dateKey == data.todayKey {
+                            context.stroke(path, with: .color(.accentColor), lineWidth: 1.5)
+                        }
                     }
                 }
             }
@@ -276,7 +279,9 @@ private struct MonthCalendarView: View {
                         .frame(maxWidth: .infinity)
                 }
 
-                ForEach(0..<offset, id: \.self) { _ in
+                // Negative IDs keep leading blanks from colliding with the 1...daysInMonth cells
+                // that share this grid's ID space.
+                ForEach(-offset..<0, id: \.self) { _ in
                     Color.clear.frame(height: 44)
                 }
 
@@ -432,10 +437,11 @@ private struct HeatmapData {
     let weeks: [[HeatmapDay?]]
     let monthLabels: [Int: String]
     let maxCount: Int
+    let todayKey: String
 
     init(history: BreakHistory, referenceDate: Date) {
-        var calendar = Calendar.current
-        calendar.firstWeekday = 2
+        let calendar = Calendar.current
+        todayKey = DailyBreakRecord.dateKey(from: referenceDate)
 
         var weeksArray: [[HeatmapDay?]] = Array(repeating: Array(repeating: nil, count: 7), count: 53)
         var labels: [Int: String] = [:]
@@ -443,12 +449,18 @@ private struct HeatmapData {
         var lastMonth = -1
         var lastLabelCol = -10
 
+        let startDate = calendar.date(byAdding: .day, value: -364, to: referenceDate) ?? referenceDate
+        // Column 0 begins on the Monday of the earliest week so every column is one real
+        // Mon-Sun week. Slicing the window into raw 7-day blocks would put two different
+        // calendar weeks in the same column whenever the window does not start on a Monday.
+        let startColumnOffset = (calendar.component(.weekday, from: startDate) + 5) % 7
+
         for dayOffset in 0..<365 {
-            guard let day = calendar.date(byAdding: .day, value: -(364 - dayOffset), to: referenceDate) else { continue }
+            guard let day = calendar.date(byAdding: .day, value: dayOffset, to: startDate) else { continue }
             let key = DailyBreakRecord.dateKey(from: day)
             let weekday = calendar.component(.weekday, from: day)
             let row = (weekday + 5) % 7
-            let col = dayOffset / 7
+            let col = (startColumnOffset + dayOffset) / 7
 
             let breakCount = history.record(for: key)?.breaksCompleted ?? 0
             if breakCount > maxBreaks { maxBreaks = breakCount }

--- a/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
@@ -104,17 +104,27 @@ public struct BreakHistory: Codable, Sendable {
 
     // MARK: - Aggregation
 
+    /// Start of the window a period covers. Week and month are calendar aligned so the totals
+    /// match the Monday-Sunday and calendar-month grids the statistics panel draws; year stays
+    /// a rolling window because the heatmap is one too.
+    private func windowStart(for period: StatsPeriod, referenceDate: Date, calendar: Calendar) -> Date {
+        switch period {
+        case .today:
+            return referenceDate
+        case .week:
+            let daysFromMonday = (calendar.component(.weekday, from: referenceDate) + 5) % 7
+            return calendar.date(byAdding: .day, value: -daysFromMonday, to: referenceDate) ?? referenceDate
+        case .month:
+            let components = calendar.dateComponents([.year, .month], from: referenceDate)
+            return calendar.date(from: components) ?? referenceDate
+        case .year:
+            return calendar.date(byAdding: .day, value: -364, to: referenceDate) ?? referenceDate
+        }
+    }
+
     public func aggregateStats(for period: StatsPeriod, referenceDate: Date = Date()) -> AggregateStats {
         let calendar = Calendar.current
-        let daysBack: Int
-        switch period {
-        case .today: daysBack = 0
-        case .week: daysBack = 6
-        case .month: daysBack = 29
-        case .year: daysBack = 364
-        }
-
-        let startDate = calendar.date(byAdding: .day, value: -daysBack, to: referenceDate)!
+        let startDate = windowStart(for: period, referenceDate: referenceDate, calendar: calendar)
         let startKey = DailyBreakRecord.dateKey(from: startDate)
         let endKey = DailyBreakRecord.dateKey(from: referenceDate)
         let filtered = records(in: startKey...endKey)

--- a/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/BreakHistory.swift
@@ -59,8 +59,14 @@ public struct BreakHistory: Codable, Sendable {
         revision += 1
     }
 
-    public mutating func pruneOlderThan(_ dateKey: String) {
+    /// Returns `true` when records were actually dropped, so the caller can skip a pointless save.
+    @discardableResult
+    public mutating func pruneOlderThan(_ dateKey: String) -> Bool {
+        let before = records.count
         records = records.filter { $0.key >= dateKey }
+        guard records.count != before else { return false }
+        revision += 1
+        return true
     }
 
     // MARK: - Streak

--- a/StandLockKit/Sources/StandLockCore/Models/Schedule.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/Schedule.swift
@@ -88,15 +88,28 @@ public enum Weekday: Int, Codable, Sendable, CaseIterable, Comparable {
     }
 }
 
-public struct TimeWindow: Codable, Sendable, Equatable {
+public struct TimeWindow: Codable, Sendable, Equatable, Identifiable {
+    /// Not persisted. It only has to stay stable for as long as a form is on screen, so SwiftUI
+    /// can track rows across insertions and deletions instead of addressing them by index.
+    public let id = UUID()
     public var startHour: Int
     public var startMinute: Int
     public var endHour: Int
     public var endMinute: Int
 
+    private enum CodingKeys: String, CodingKey {
+        case startHour, startMinute, endHour, endMinute
+    }
+
     public init(startHour: Int, startMinute: Int, endHour: Int, endMinute: Int) {
         self.startHour = startHour; self.startMinute = startMinute
         self.endHour = endHour; self.endMinute = endMinute
+    }
+
+    /// Identity is per-session only, so equality stays on the values a window actually stores.
+    public static func == (lhs: TimeWindow, rhs: TimeWindow) -> Bool {
+        lhs.startHour == rhs.startHour && lhs.startMinute == rhs.startMinute
+            && lhs.endHour == rhs.endHour && lhs.endMinute == rhs.endMinute
     }
 
     public func contains(hour: Int, minute: Int) -> Bool {

--- a/StandLockKit/Tests/StandLockCoreTests/BreakHistoryTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/BreakHistoryTests.swift
@@ -95,22 +95,47 @@ struct BreakHistoryTests {
         #expect(stats.totalSkipped == 1)
     }
 
-    @Test func aggregateWeekSumsLast7Days() {
+    @Test func aggregateWeekCoversCalendarWeekFromMonday() {
         var history = BreakHistory()
-        let ref = date("2026-06-01")
-        let calendar = Calendar.current
+        let ref = date("2026-06-04") // Thursday
 
-        for offset in 0..<7 {
-            let day = calendar.date(byAdding: .day, value: -offset, to: ref)!
-            let key = DailyBreakRecord.dateKey(from: day)
+        for key in ["2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04"] {
             history.upsert(makeRecord(key, completed: 2, duration: 600))
         }
-        let outside = calendar.date(byAdding: .day, value: -7, to: ref)!
-        history.upsert(makeRecord(DailyBreakRecord.dateKey(from: outside), completed: 100))
+        // Sunday closing the previous week. Within the trailing 7 days, outside this week.
+        history.upsert(makeRecord("2026-05-31", completed: 100))
 
         let stats = history.aggregateStats(for: .week, referenceDate: ref)
-        #expect(stats.totalCompleted == 14)
-        #expect(stats.totalBreakTime == 4200)
+        #expect(stats.totalCompleted == 8)
+        #expect(stats.totalBreakTime == 2400)
+        #expect(stats.activeDays == 4)
+    }
+
+    @Test func aggregateMonthCoversCalendarMonth() {
+        var history = BreakHistory()
+        let ref = date("2026-06-15")
+
+        history.upsert(makeRecord("2026-06-01", completed: 3))
+        history.upsert(makeRecord("2026-06-15", completed: 4))
+        // Within the trailing 30 days, outside the calendar month.
+        history.upsert(makeRecord("2026-05-31", completed: 100))
+
+        let stats = history.aggregateStats(for: .month, referenceDate: ref)
+        #expect(stats.totalCompleted == 7)
+        #expect(stats.activeDays == 2)
+    }
+
+    @Test func aggregateWeekOnSundayStillStartsOnMonday() {
+        var history = BreakHistory()
+        let ref = date("2026-06-07") // Sunday
+
+        history.upsert(makeRecord("2026-06-01", completed: 1)) // Monday, first day of the week
+        history.upsert(makeRecord("2026-06-07", completed: 1))
+        history.upsert(makeRecord("2026-05-31", completed: 100)) // previous Sunday
+
+        let stats = history.aggregateStats(for: .week, referenceDate: ref)
+        #expect(stats.totalCompleted == 2)
+        #expect(stats.activeDays == 2)
     }
 
     @Test func aggregateYearSums365Days() {


### PR DESCRIPTION
## Summary

Six defects found while reviewing the statistics path after #33. They are unrelated to each other beyond the surface they sit on, so each has its own commit.

- **`fix(break): bound the crate spin by the attempt limit`** -- `usedAttempts` is sized to `maxAttempts`, but `spin()` only guarded against a spin already in flight. A losing spin on the last attempt left the button live, and the next tap wrote past the end of the array.
- **`fix(schedule): identify time window rows instead of indexing them`** -- `ForEach(windows.indices)` makes the index the identity, so removing a row left SwiftUI holding an index that no longer existed and the `$windows[index]` bindings read out of range. `TimeWindow` now carries an id, excluded from `CodingKeys` so persisted schedules are unchanged and from `==` so equality still compares the stored times.
- **`fix(stats): persist break history after pruning old records`** -- startup pruning dropped records older than 400 days from memory but never wrote the result back, so the same records were reloaded and pruned again on every launch.
- **`fix(stats): align the week and month totals to the calendar`** -- see below.
- **`fix(stats): refresh the statistics caches when they go stale`** -- switching periods rebuilt the totals but not the heatmap, and neither cache was invalidated at midnight, so a panel left open across the day boundary kept drawing yesterday. The 365-day heatmap is now built only for the Year tab.
- **`fix(stats): correct the heatmap and month grid layout`** -- the heatmap sliced its window into raw 7-day blocks, so unless the window started on a Monday a column spanned two calendar weeks; today's cell was indistinguishable from any other; the month grid's leading blanks shared an ID space with the day cells.

## Behaviour change

Week and Month in Statistics summed the trailing 7 and 30 days while the grids under them drew a Monday-to-Sunday week and a calendar month, so the totals disagreed with the cells they sat above. Both windows are now calendar aligned. Year stays a rolling 365 days because its heatmap is a rolling window too.

This changes what the existing numbers mean and needs a release note.

## Test plan

- [x] 157/157 tests pass, macOS build clean
- [ ] Leave Statistics open across midnight: the heatmap and totals move to the new day
- [ ] Switch to Year and back: the heatmap still renders
- [ ] Check a Monday and a Sunday: the Week total matches the days the grid highlights
- [ ] Remove the middle window from a schedule with three: the right row goes, no crash
- [ ] Lose every crate spin: the button stops at the last attempt
