### PR TITLE
Add alternating break intervals with per-interval labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+**New**
+- A schedule can now cycle through multiple work intervals instead of one, e.g. 58 min sitting > 2 min break > 28 min standing > 2 min break > repeat. Each interval can carry an optional label, and the break screen shows what comes next ("NEXT: STANDING"). The cycle stays on plan regardless of how a break ends, and each day starts from the first interval. Existing single-interval schedules are unchanged (fixes #30, #35)
+
 ## StandLock v0.2.8
 
 **Bug Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 **New**
-- A schedule can now cycle through multiple work intervals instead of one, e.g. 58 min sitting > 2 min break > 28 min standing > 2 min break > repeat. Each interval can carry an optional label, and the break screen shows what comes next ("NEXT: STANDING"). The cycle stays on plan regardless of how a break ends, and each day starts from the first interval. Existing single-interval schedules are unchanged (fixes #30, #35)
+- A schedule can now cycle through multiple work intervals instead of one, e.g. 58 min sitting > 2 min break > 28 min standing > 2 min break > repeat. Each interval can carry an optional label, and the break screen shows what comes next ("NEXT: STANDING"). The cycle stays on plan regardless of how a break ends, and each day starts from the first interval. Existing single-interval schedules are unchanged (fixes #30, 8f21732)
+
+**Notes**
+- The position within an interval cycle is not saved. Quitting and relaunching restarts the cycle at its first interval, even mid-day.
 
 ## StandLock v0.2.8
 

--- a/StandLock.xcodeproj/project.pbxproj
+++ b/StandLock.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6AF974084F51158A71D9EA47 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512EB234C46341A2816AAE12 /* SettingsView.swift */; };
 		6F9C00664AAD42633900A642 /* Exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 2063FDE70AFCC135664A8FD4 /* Exercises.json */; };
 		726D144CA2B3B5AF4D4503AE /* LevelPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6724F4176D1F398DF9A697 /* LevelPill.swift */; };
+		D3B096DA1A8A43639099F280 /* NextIntervalLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EE4109FB254184AE58E99E /* NextIntervalLabel.swift */; };
 		742A80C38BAB206209CC4213 /* WelcomeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B387012391C6BC0360436B50 /* WelcomeStepView.swift */; };
 		75E31F36751D55F051D6FF34 /* ExerciseBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434445F0717D4FC94E284CB8 /* ExerciseBlock.swift */; };
 		82BDAFFF1661ED2476DDCAD3 /* Detection in Frameworks */ = {isa = PBXBuildFile; productRef = F19E05A1FA932709D406DD8F /* Detection */; };
@@ -78,6 +79,7 @@
 		A81F2ED91290AD26CB5B672E /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		A866831BDFD42E80353C80D8 /* DisciplineLevelPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisciplineLevelPicker.swift; sourceTree = "<group>"; };
 		AF6724F4176D1F398DF9A697 /* LevelPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelPill.swift; sourceTree = "<group>"; };
+		C2EE4109FB254184AE58E99E /* NextIntervalLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextIntervalLabel.swift; sourceTree = "<group>"; };
 		B1524D749BB78A875E5FD51F /* StandLockApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandLockApp.swift; sourceTree = "<group>"; };
 		B387012391C6BC0360436B50 /* WelcomeStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeStepView.swift; sourceTree = "<group>"; };
 		C5BBDBF97CFAA5FF490CBD00 /* BreakOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakOverlayWindow.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				434445F0717D4FC94E284CB8 /* ExerciseBlock.swift */,
 				AF6724F4176D1F398DF9A697 /* LevelPill.swift */,
 				99BB0E055C4BD25865AD3EE1 /* ManuscriptBreakView.swift */,
+				C2EE4109FB254184AE58E99E /* NextIntervalLabel.swift */,
 				43B1BE95A60D5294C770AEDE /* StatsFooter.swift */,
 				DEAF9C8AFAF33310B45445B2 /* TimerNumerals.swift */,
 				85C5398AE9D97E6B58618468 /* WordmarkView.swift */,
@@ -329,6 +332,7 @@
 				09F7858EAC29160F684A60DD /* GeneralSettingsView.swift in Sources */,
 				726D144CA2B3B5AF4D4503AE /* LevelPill.swift in Sources */,
 				D751E70A3ADA8406061C5A90 /* ManuscriptBreakView.swift in Sources */,
+				D3B096DA1A8A43639099F280 /* NextIntervalLabel.swift in Sources */,
 				F1A2B3C4D5E6F7081920A1B2 /* MediaController.swift in Sources */,
 				D4E5F6A7B8C9D0E1F2A3B4C6 /* MenuBarIcon.swift in Sources */,
 				1CCAA6FDBBB854DCBC1968EA /* MenuBarView.swift in Sources */,

--- a/StandLock/AppState/OverlayWindowController.swift
+++ b/StandLock/AppState/OverlayWindowController.swift
@@ -18,6 +18,7 @@ final class OverlayWindowController: LockPresenting {
     private var currentPreferences: AppPreferences?
     private var currentStatistics: BreakStatistics?
     private var currentEscalationTier: Int = 0
+    private var currentNextIntervalLabel: String?
     private var breakStartDate: Date?
     private var lastScreenChangeHandled: Date = .distantPast
 
@@ -30,7 +31,8 @@ final class OverlayWindowController: LockPresenting {
     func showOverlay(
         level: DisciplineLevel, duration: TimeInterval,
         exercise: Exercise?, preferences: AppPreferences,
-        statistics: BreakStatistics, escalationTier: Int = 0
+        statistics: BreakStatistics, escalationTier: Int = 0,
+        nextIntervalLabel: String? = nil
     ) {
         let isRecreation = isShowing
         dismissOverlay()
@@ -44,6 +46,7 @@ final class OverlayWindowController: LockPresenting {
         currentPreferences = preferences
         currentStatistics = statistics
         currentEscalationTier = escalationTier
+        currentNextIntervalLabel = nextIntervalLabel
 
         let palette = BreakPalette.for(level)
         for screen in NSScreen.screens {
@@ -53,6 +56,7 @@ final class OverlayWindowController: LockPresenting {
                 level: level, totalDuration: duration,
                 exercise: exercise, preferences: preferences,
                 statistics: statistics, escalationTier: escalationTier,
+                nextIntervalLabel: nextIntervalLabel,
                 onSkip: { [weak self] in self?.handleSkip() },
                 onEscape: { [weak self] in self?.handleEscape() },
                 onComplete: { [weak self] in self?.handleComplete() }
@@ -189,11 +193,13 @@ final class OverlayWindowController: LockPresenting {
         let remaining = currentDuration - elapsed
         let tier = currentEscalationTier
         let exercise = currentExercise
+        let nextLabel = currentNextIntervalLabel
         dismissOverlay()
         showOverlay(
             level: level, duration: remaining,
             exercise: exercise, preferences: prefs,
-            statistics: stats, escalationTier: tier
+            statistics: stats, escalationTier: tier,
+            nextIntervalLabel: nextLabel
         )
     }
 }

--- a/StandLock/Views/BreakScreen/ManuscriptBreakView.swift
+++ b/StandLock/Views/BreakScreen/ManuscriptBreakView.swift
@@ -9,6 +9,7 @@ struct ManuscriptBreakView: View {
     let statistics: BreakStatistics
     let enforcementTier: EnforcementTier
     let escalationTierIndex: Int
+    let nextIntervalLabel: String?
     let onSkip: () -> Void
     let onEscape: () -> Void
     let onComplete: () -> Void
@@ -21,6 +22,7 @@ struct ManuscriptBreakView: View {
     init(level: DisciplineLevel, totalDuration: TimeInterval, exercise: Exercise?,
          preferences: AppPreferences, statistics: BreakStatistics,
          escalationTier: Int = 0,
+         nextIntervalLabel: String? = nil,
          onSkip: @escaping () -> Void,
          onEscape: @escaping () -> Void,
          onComplete: @escaping () -> Void) {
@@ -32,6 +34,7 @@ struct ManuscriptBreakView: View {
         let policy = level.enforcementPolicy(preferences: preferences)
         self.enforcementTier = policy.tier(at: escalationTier)
         self.escalationTierIndex = escalationTier
+        self.nextIntervalLabel = nextIntervalLabel
         self.onSkip = onSkip
         self.onEscape = onEscape
         self.onComplete = onComplete
@@ -55,6 +58,9 @@ struct ManuscriptBreakView: View {
 
                     VStack(spacing: compact ? 16 : 24) {
                         LevelPill(level: level, palette: palette)
+                        if let nextIntervalLabel, !nextIntervalLabel.isEmpty {
+                            NextIntervalLabel(text: nextIntervalLabel, palette: palette)
+                        }
                         TimerNumerals(
                             remainingSeconds: remainingSeconds,
                             totalDuration: totalDuration,

--- a/StandLock/Views/BreakScreen/NextIntervalLabel.swift
+++ b/StandLock/Views/BreakScreen/NextIntervalLabel.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct NextIntervalLabel: View {
+    let text: String
+    let palette: BreakPalette
+
+    var body: some View {
+        Text("NEXT: \(text)".uppercased())
+            .font(BreakTypography.label(size: 11, weight: .medium))
+            .tracking(0.12)
+            .foregroundStyle(palette.inkFaint)
+    }
+}

--- a/StandLock/Views/Settings/ScheduleEditorView.swift
+++ b/StandLock/Views/Settings/ScheduleEditorView.swift
@@ -190,6 +190,10 @@ private struct ScheduleRow: View {
     }
 
     private var intervalSummary: String {
+        if let cycle = schedule.intervalCycle, cycle.count >= 2 {
+            let minutes = cycle.map { String(Int($0.duration / 60)) }
+            return "every " + minutes.joined(separator: "/") + "m"
+        }
         let minutes = Int(schedule.breakInterval / 60)
         return "every \(minutes)m"
     }

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -171,6 +171,8 @@ struct ScheduleFormView: View {
                                 .foregroundStyle(.secondary)
 
                             if intervalRows.count > 1 {
+                                TextField("Label (optional, e.g. Sitting)", text: $row.label)
+                                    .textFieldStyle(.roundedBorder)
                                 Button {
                                     intervalRows.removeAll { $0.id == row.id }
                                 } label: {

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -343,9 +343,11 @@ struct ScheduleFormView: View {
             return IntervalStep(duration: TimeInterval(row.minutes * 60),
                                 label: trimmed.isEmpty ? nil : trimmed)
         }
-        // A single unlabeled row is the canonical single-interval schedule; `breakInterval`
-        // always mirrors the first entry so old readers see a sane single interval.
-        let intervalCycle: [IntervalStep]? = (steps.count == 1 && steps[0].label == nil) ? nil : steps
+        // A single row is the canonical single-interval schedule; `breakInterval` always
+        // mirrors the first entry so old readers see a sane single interval. The label field
+        // is hidden at one row, so a label left over from a deleted row must not persist --
+        // it would be invisible, unclearable, and still drive the break screen.
+        let intervalCycle: [IntervalStep]? = steps.count == 1 ? nil : steps
 
         let result = Schedule(
             id: schedule?.id ?? UUID(),

--- a/StandLock/Views/Settings/ScheduleFormView.swift
+++ b/StandLock/Views/Settings/ScheduleFormView.swift
@@ -10,7 +10,7 @@ struct ScheduleFormView: View {
     @State private var dayPreset: DayPreset = .weekdays
     @State private var customDays: Set<Weekday> = []
     @State private var windows: [TimeWindow] = [TimeWindow(startHour: 9, startMinute: 0, endHour: 17, endMinute: 0)]
-    @State private var breakIntervalMinutes: Int = 40
+    @State private var intervalRows: [IntervalRowModel] = [IntervalRowModel(minutes: 40)]
     @State private var breakDurationMinutes: Int = 10
     @State private var useRepetition: Bool = false
     @State private var shortBreakCount: Int = 3
@@ -151,22 +151,43 @@ struct ScheduleFormView: View {
             Text("Timing")
                 .font(.subheadline.weight(.medium))
 
-            HStack(spacing: 24) {
+            HStack(alignment: .top, spacing: 24) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Break every")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    HStack(spacing: 4) {
-                        TextField("", value: $breakIntervalMinutes, format: .number)
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 50)
-                            .onChange(of: breakIntervalMinutes) { newValue in
-                                breakIntervalMinutes = max(1, min(180, newValue))
+                    // Bound by identity for the same reason as the windows section.
+                    ForEach($intervalRows) { $row in
+                        HStack(spacing: 4) {
+                            TextField("", value: $row.minutes, format: .number)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 50)
+                                .onChange(of: row.minutes) { newValue in
+                                    row.minutes = max(1, min(180, newValue))
+                                }
+                            Stepper("", value: $row.minutes, in: 1...180, step: 5)
+                                .labelsHidden()
+                            Text("min")
+                                .foregroundStyle(.secondary)
+
+                            if intervalRows.count > 1 {
+                                Button {
+                                    intervalRows.removeAll { $0.id == row.id }
+                                } label: {
+                                    Image(systemName: "minus.circle")
+                                        .foregroundStyle(.red)
+                                }
+                                .buttonStyle(.plain)
                             }
-                        Stepper("", value: $breakIntervalMinutes, in: 1...180, step: 5)
-                            .labelsHidden()
-                        Text("min")
-                            .foregroundStyle(.secondary)
+                        }
+                    }
+                    if intervalRows.count < 6 {
+                        Button {
+                            intervalRows.append(IntervalRowModel(minutes: 40))
+                        } label: {
+                            Image(systemName: "plus.circle")
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
 
@@ -187,6 +208,12 @@ struct ScheduleFormView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+
+            if intervalRows.count > 1 {
+                Text("Breaks cycle through these intervals in order.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -267,7 +294,11 @@ struct ScheduleFormView: View {
         guard let s = schedule else { return }
         name = s.name
         windows = s.windows
-        breakIntervalMinutes = Int(s.breakInterval / 60)
+        if let cycle = s.intervalCycle, !cycle.isEmpty {
+            intervalRows = cycle.map { IntervalRowModel(minutes: Int($0.duration / 60), label: $0.label ?? "") }
+        } else {
+            intervalRows = [IntervalRowModel(minutes: Int(s.breakInterval / 60))]
+        }
         breakDurationMinutes = Int(s.breakDuration / 60)
         disciplineLevel = s.disciplineLevel
         progressiveEnforcement = s.progressiveEnforcement
@@ -305,20 +336,37 @@ struct ScheduleFormView: View {
             )
             : nil
 
+        let steps = intervalRows.map { row -> IntervalStep in
+            let trimmed = row.label.trimmingCharacters(in: .whitespaces)
+            return IntervalStep(duration: TimeInterval(row.minutes * 60),
+                                label: trimmed.isEmpty ? nil : trimmed)
+        }
+        // A single unlabeled row is the canonical single-interval schedule; `breakInterval`
+        // always mirrors the first entry so old readers see a sane single interval.
+        let intervalCycle: [IntervalStep]? = (steps.count == 1 && steps[0].label == nil) ? nil : steps
+
         let result = Schedule(
             id: schedule?.id ?? UUID(),
             name: name.trimmingCharacters(in: .whitespaces),
             isEnabled: schedule?.isEnabled ?? true,
             days: days,
             windows: windows,
-            breakInterval: TimeInterval(breakIntervalMinutes * 60),
+            breakInterval: steps[0].duration,
             breakDuration: TimeInterval(breakDurationMinutes * 60),
+            intervalCycle: intervalCycle,
             repetitionRule: repetitionRule,
             disciplineLevel: disciplineLevel,
             progressiveEnforcement: progressiveEnforcement
         )
         onSave(result)
     }
+}
+
+/// Session-only row identity, same non-persisted-id pattern as `TimeWindow.id`.
+private struct IntervalRowModel: Identifiable {
+    let id = UUID()
+    var minutes: Int
+    var label: String = ""
 }
 
 private enum DayPreset {

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -23,6 +23,11 @@ public final class BreakCoordinator {
     private var statistics: BreakStatistics = BreakStatistics()
     private var dailyBreakCounts: [UUID: Int] = [:]
     private var escalationTiers: [UUID: Int] = [:]
+    private var cycleIndices: [UUID: Int] = [:]
+    /// Which schedule the armed break timer targets. A menu skip of a not-yet-fired break has
+    /// to advance that schedule's cycle; cleared whenever the timer is cancelled or the break
+    /// becomes active, so a slot can never advance twice.
+    private var pendingBreakScheduleID: UUID?
     public var exercises: [Exercise] = []
 
     private let deferralPollingInterval: TimeInterval
@@ -58,6 +63,7 @@ public final class BreakCoordinator {
     public func stop() {
         breakTimer?.cancel()
         breakTimer = nil
+        pendingBreakScheduleID = nil
         if locker.isShowing { locker.dismissOverlay() }
         currentBreak = nil
         currentSchedule = nil
@@ -67,6 +73,7 @@ public final class BreakCoordinator {
     public func pause(for duration: TimeInterval) {
         breakTimer?.cancel()
         breakTimer = nil
+        pendingBreakScheduleID = nil
         isPaused = true
         let until = Date().addingTimeInterval(duration)
         eventContinuation.yield(.schedulePaused(until: until))
@@ -87,11 +94,12 @@ public final class BreakCoordinator {
     /// it is a no-op while the recorded day is still the current one.
     public func refreshDailyRollover(now: Date = Date()) {
         guard rolloverIfNeeded(now: now) else { return }
-        // A schedule that exhausted its daily cap leaves no pending timer behind, so it has to
-        // be re-armed once the new day frees the cap. Nothing may be armed behind a locked or
-        // sleeping screen, and a live timer is never touched: while paused it holds the resume
-        // task, and otherwise it holds the next break.
-        if !isPaused && !isSuspended && breakTimer == nil {
+        // Re-arm on every rollover: a schedule that exhausted its daily cap left no timer
+        // behind, and a timer armed before midnight was computed from the old day's cycle
+        // index -- the new day's first break must come from index 0 (scheduleNextBreak
+        // cancels any pending timer itself). Nothing may be armed behind a locked or
+        // sleeping screen, and while paused the timer holds the resume task.
+        if !isPaused && !isSuspended {
             scheduleNextBreak(now: now)
         }
     }
@@ -103,6 +111,8 @@ public final class BreakCoordinator {
         dailyBreakCounts.removeAll()
         // Progressive enforcement escalates within a day; a new day starts from the base tier.
         escalationTiers.removeAll()
+        // Every day starts the interval cycle from its first entry.
+        cycleIndices.removeAll()
         eventContinuation.yield(.statisticsUpdated(statistics))
         return true
     }
@@ -144,6 +154,7 @@ public final class BreakCoordinator {
     private func cancelAndDismissIfShowing() {
         breakTimer?.cancel()
         breakTimer = nil
+        pendingBreakScheduleID = nil
         if locker.isShowing {
             locker.dismissOverlay()
             if var event = currentBreak {
@@ -162,6 +173,10 @@ public final class BreakCoordinator {
     public func skipNextBreak() {
         breakTimer?.cancel()
         breakTimer = nil
+        if let id = pendingBreakScheduleID {
+            cycleIndices[id, default: 0] += 1
+            pendingBreakScheduleID = nil
+        }
         updateStatistics {
             $0.breaksSkipped += 1
             $0.currentStreak = 0
@@ -244,7 +259,8 @@ public final class BreakCoordinator {
         for schedule in activeSchedules where schedule.isEnabled {
             if let cap = schedule.dailyBreakCap,
                (dailyBreakCounts[schedule.id] ?? 0) >= cap { continue }
-            if let next = scheduler.nextBreakTime(for: schedule, after: now, cycleIndex: 0) {
+            if let next = scheduler.nextBreakTime(for: schedule, after: now,
+                                                  cycleIndex: cycleIndices[schedule.id, default: 0]) {
                 if earliest == nil || next < earliest!.date {
                     earliest = (next, schedule)
                 }
@@ -252,6 +268,7 @@ public final class BreakCoordinator {
         }
 
         guard let target = earliest else { return }
+        pendingBreakScheduleID = target.schedule.id
         eventContinuation.yield(.nextBreakScheduled(target.date))
 
         breakTimer = Task {
@@ -274,6 +291,8 @@ public final class BreakCoordinator {
     }
 
     private func triggerBreak(for schedule: Schedule, context: DetectionContext) async {
+        // The pending break is now active; a menu skip from here on must not advance again.
+        pendingBreakScheduleID = nil
         rolloverIfNeeded()
         if preferences.idleDetectionEnabled {
             let breakDuration = currentBreakDuration(for: schedule)
@@ -288,6 +307,7 @@ public final class BreakCoordinator {
                     repetitionTrackers[schedule.id] = tracker
                 }
                 dailyBreakCounts[schedule.id, default: 0] += 1
+                cycleIndices[schedule.id, default: 0] += 1
                 escalationTiers[schedule.id] = 0
                 eventContinuation.yield(.breakCompleted(idleEvent))
                 updateStatistics {
@@ -300,6 +320,9 @@ public final class BreakCoordinator {
         }
 
         if let deferral = shouldDefer(context: context) {
+            // The deferred slot is still pending, so a menu skip during the poll loop
+            // must conclude it for this schedule.
+            pendingBreakScheduleID = schedule.id
             eventContinuation.yield(.breakDeferred(deferral, nextAttempt: Date().addingTimeInterval(deferralPollingInterval)))
             updateStatistics { $0.breaksDeferred += 1 }
             breakTimer = Task {
@@ -310,6 +333,8 @@ public final class BreakCoordinator {
                     if let newReason = self.shouldDefer(context: freshContext) {
                         self.eventContinuation.yield(.breakDeferred(newReason, nextAttempt: Date().addingTimeInterval(self.deferralPollingInterval)))
                     } else if self.shouldSkipAfterDeferral(reason: deferral) {
+                        self.cycleIndices[schedule.id, default: 0] += 1
+                        self.pendingBreakScheduleID = nil
                         self.scheduleNextBreak()
                         return
                     } else {
@@ -336,6 +361,7 @@ public final class BreakCoordinator {
         currentBreak = breakEvent
         currentSchedule = schedule
         dailyBreakCounts[schedule.id, default: 0] += 1
+        cycleIndices[schedule.id, default: 0] += 1
 
         eventContinuation.yield(.breakStarted(breakEvent))
         locker.showOverlay(level: effectiveLevel, duration: duration,

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -366,7 +366,15 @@ public final class BreakCoordinator {
         eventContinuation.yield(.breakStarted(breakEvent))
         locker.showOverlay(level: effectiveLevel, duration: duration,
                            exercise: exercise, preferences: preferences,
-                           statistics: statistics, escalationTier: tier)
+                           statistics: statistics, escalationTier: tier,
+                           nextIntervalLabel: nextIntervalLabel(for: schedule))
+    }
+
+    /// The cycle index was already advanced when this break triggered, so it points at the
+    /// upcoming work block.
+    private func nextIntervalLabel(for schedule: Schedule) -> String? {
+        guard let cycle = schedule.intervalCycle, !cycle.isEmpty else { return nil }
+        return cycle[cycleIndices[schedule.id, default: 0] % cycle.count].label
     }
 
     private func currentBreakDuration(for schedule: Schedule) -> TimeInterval {

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -28,6 +28,9 @@ public final class BreakCoordinator {
     /// to advance that schedule's cycle; cleared whenever the timer is cancelled or the break
     /// becomes active, so a slot can never advance twice.
     private var pendingBreakScheduleID: UUID?
+    /// True only while the deferral poll loop owns `breakTimer`. That loop is suspended between
+    /// polls, so anything that re-arms the timer cancels it and drops the deferred break.
+    private var isDeferringBreak = false
     public var exercises: [Exercise] = []
 
     private let deferralPollingInterval: TimeInterval
@@ -63,7 +66,7 @@ public final class BreakCoordinator {
     public func stop() {
         breakTimer?.cancel()
         breakTimer = nil
-        pendingBreakScheduleID = nil
+        clearPendingBreak()
         if locker.isShowing { locker.dismissOverlay() }
         currentBreak = nil
         currentSchedule = nil
@@ -73,7 +76,7 @@ public final class BreakCoordinator {
     public func pause(for duration: TimeInterval) {
         breakTimer?.cancel()
         breakTimer = nil
-        pendingBreakScheduleID = nil
+        clearPendingBreak()
         isPaused = true
         let until = Date().addingTimeInterval(duration)
         eventContinuation.yield(.schedulePaused(until: until))
@@ -98,8 +101,9 @@ public final class BreakCoordinator {
         // behind, and a timer armed before midnight was computed from the old day's cycle
         // index -- the new day's first break must come from index 0 (scheduleNextBreak
         // cancels any pending timer itself). Nothing may be armed behind a locked or
-        // sleeping screen, and while paused the timer holds the resume task.
-        if !isPaused && !isSuspended {
+        // sleeping screen, while paused the timer holds the resume task, and re-arming
+        // during a deferral would cancel the poll loop and lose the deferred break.
+        if !isPaused && !isSuspended && !isDeferringBreak {
             scheduleNextBreak(now: now)
         }
     }
@@ -154,7 +158,7 @@ public final class BreakCoordinator {
     private func cancelAndDismissIfShowing() {
         breakTimer?.cancel()
         breakTimer = nil
-        pendingBreakScheduleID = nil
+        clearPendingBreak()
         if locker.isShowing {
             locker.dismissOverlay()
             if var event = currentBreak {
@@ -175,8 +179,8 @@ public final class BreakCoordinator {
         breakTimer = nil
         if let id = pendingBreakScheduleID {
             cycleIndices[id, default: 0] += 1
-            pendingBreakScheduleID = nil
         }
+        clearPendingBreak()
         updateStatistics {
             $0.breaksSkipped += 1
             $0.currentStreak = 0
@@ -245,6 +249,13 @@ public final class BreakCoordinator {
 
     // MARK: - Private
 
+    /// The pending slot and the deferral flag always end together: whoever concludes a slot
+    /// concludes the poll that was waiting on it.
+    private func clearPendingBreak() {
+        pendingBreakScheduleID = nil
+        isDeferringBreak = false
+    }
+
     /// `now` governs both the rollover check and the search for the next break, so an injected
     /// date describes one consistent moment. Without it the rollover here would re-read the real
     /// clock and undo a caller-injected day change, since `resetDailyIfNeeded` fires in both
@@ -292,7 +303,7 @@ public final class BreakCoordinator {
 
     private func triggerBreak(for schedule: Schedule, context: DetectionContext) async {
         // The pending break is now active; a menu skip from here on must not advance again.
-        pendingBreakScheduleID = nil
+        clearPendingBreak()
         rolloverIfNeeded()
         if preferences.idleDetectionEnabled {
             let breakDuration = currentBreakDuration(for: schedule)
@@ -323,6 +334,7 @@ public final class BreakCoordinator {
             // The deferred slot is still pending, so a menu skip during the poll loop
             // must conclude it for this schedule.
             pendingBreakScheduleID = schedule.id
+            isDeferringBreak = true
             eventContinuation.yield(.breakDeferred(deferral, nextAttempt: Date().addingTimeInterval(deferralPollingInterval)))
             updateStatistics { $0.breaksDeferred += 1 }
             breakTimer = Task {
@@ -330,11 +342,14 @@ public final class BreakCoordinator {
                     try? await Task.sleep(for: .seconds(self.deferralPollingInterval))
                     guard !Task.isCancelled else { return }
                     let freshContext = await self.detector.currentContext()
+                    // Cancellation does not interrupt the await above, so re-check before
+                    // mutating: a menu skip during it already concluded this slot.
+                    guard !Task.isCancelled else { return }
                     if let newReason = self.shouldDefer(context: freshContext) {
                         self.eventContinuation.yield(.breakDeferred(newReason, nextAttempt: Date().addingTimeInterval(self.deferralPollingInterval)))
                     } else if self.shouldSkipAfterDeferral(reason: deferral) {
                         self.cycleIndices[schedule.id, default: 0] += 1
-                        self.pendingBreakScheduleID = nil
+                        self.clearPendingBreak()
                         self.scheduleNextBreak()
                         return
                     } else {

--- a/StandLockKit/Sources/Coordination/BreakCoordinator.swift
+++ b/StandLockKit/Sources/Coordination/BreakCoordinator.swift
@@ -244,7 +244,7 @@ public final class BreakCoordinator {
         for schedule in activeSchedules where schedule.isEnabled {
             if let cap = schedule.dailyBreakCap,
                (dailyBreakCounts[schedule.id] ?? 0) >= cap { continue }
-            if let next = scheduler.nextBreakTime(for: schedule, after: now) {
+            if let next = scheduler.nextBreakTime(for: schedule, after: now, cycleIndex: 0) {
                 if earliest == nil || next < earliest!.date {
                     earliest = (next, schedule)
                 }

--- a/StandLockKit/Sources/Scheduling/ScheduleEvaluator.swift
+++ b/StandLockKit/Sources/Scheduling/ScheduleEvaluator.swift
@@ -16,24 +16,30 @@ public struct ScheduleEvaluator: SchedulingEngine, Sendable {
         return schedule.windows.contains { $0.contains(hour: hour, minute: minute) }
     }
 
-    public func nextBreakTime(for schedule: Schedule, after date: Date) -> Date? {
+    public func nextBreakTime(for schedule: Schedule, after date: Date, cycleIndex: Int) -> Date? {
         let calendar = Calendar.current
+        let interval = interval(for: schedule, cycleIndex: cycleIndex)
 
         if isWithinActiveWindow(schedule, at: date) {
-            let candidate = date.addingTimeInterval(schedule.breakInterval)
+            let candidate = date.addingTimeInterval(interval)
             if isWithinActiveWindow(schedule, at: candidate) {
                 return candidate
             }
             if let nextWindow = nextWindowStart(for: schedule, after: date, calendar: calendar) {
-                return nextWindow.addingTimeInterval(schedule.breakInterval)
+                return nextWindow.addingTimeInterval(interval)
             }
         }
 
         if let nextWindow = nextWindowStart(for: schedule, after: date, calendar: calendar) {
-            return nextWindow.addingTimeInterval(schedule.breakInterval)
+            return nextWindow.addingTimeInterval(interval)
         }
 
         return nil
+    }
+
+    private func interval(for schedule: Schedule, cycleIndex: Int) -> TimeInterval {
+        guard let cycle = schedule.intervalCycle, !cycle.isEmpty else { return schedule.breakInterval }
+        return cycle[cycleIndex % cycle.count].duration
     }
 
     public func breakDuration(for schedule: Schedule, breakIndex: Int) -> TimeInterval {

--- a/StandLockKit/Sources/StandLockCore/Models/Schedule.swift
+++ b/StandLockKit/Sources/StandLockCore/Models/Schedule.swift
@@ -8,6 +8,7 @@ public struct Schedule: Codable, Sendable, Identifiable, Equatable {
     public var windows: [TimeWindow]
     public var breakInterval: TimeInterval
     public var breakDuration: TimeInterval
+    public var intervalCycle: [IntervalStep]?
     public var repetitionRule: RepetitionRule?
     public var disciplineLevel: DisciplineLevel
     public var dailyBreakCap: Int?
@@ -17,6 +18,7 @@ public struct Schedule: Codable, Sendable, Identifiable, Equatable {
         id: UUID = UUID(), name: String, isEnabled: Bool = true,
         days: DaySelection, windows: [TimeWindow],
         breakInterval: TimeInterval, breakDuration: TimeInterval,
+        intervalCycle: [IntervalStep]? = nil,
         repetitionRule: RepetitionRule? = nil,
         disciplineLevel: DisciplineLevel = .gentle,
         dailyBreakCap: Int? = nil,
@@ -25,6 +27,7 @@ public struct Schedule: Codable, Sendable, Identifiable, Equatable {
         self.id = id; self.name = name; self.isEnabled = isEnabled
         self.days = days; self.windows = windows
         self.breakInterval = breakInterval; self.breakDuration = breakDuration
+        self.intervalCycle = intervalCycle
         self.repetitionRule = repetitionRule
         self.disciplineLevel = disciplineLevel; self.dailyBreakCap = dailyBreakCap
         self.progressiveEnforcement = progressiveEnforcement
@@ -32,7 +35,7 @@ public struct Schedule: Codable, Sendable, Identifiable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, isEnabled, days, windows
-        case breakInterval, breakDuration, repetitionRule
+        case breakInterval, breakDuration, intervalCycle, repetitionRule
         case disciplineLevel, dailyBreakCap, progressiveEnforcement
     }
 
@@ -45,6 +48,7 @@ public struct Schedule: Codable, Sendable, Identifiable, Equatable {
         windows = try c.decode([TimeWindow].self, forKey: .windows)
         breakInterval = try c.decode(TimeInterval.self, forKey: .breakInterval)
         breakDuration = try c.decode(TimeInterval.self, forKey: .breakDuration)
+        intervalCycle = try c.decodeIfPresent([IntervalStep].self, forKey: .intervalCycle)
         repetitionRule = try c.decodeIfPresent(RepetitionRule.self, forKey: .repetitionRule)
         disciplineLevel = try c.decodeIfPresent(DisciplineLevel.self, forKey: .disciplineLevel) ?? .gentle
         dailyBreakCap = try c.decodeIfPresent(Int.self, forKey: .dailyBreakCap)
@@ -120,6 +124,16 @@ public struct TimeWindow: Codable, Sendable, Equatable, Identifiable {
             return time >= start && time < end
         }
         return time >= start || time < end
+    }
+}
+
+public struct IntervalStep: Codable, Sendable, Equatable {
+    public var duration: TimeInterval
+    public var label: String?
+
+    public init(duration: TimeInterval, label: String? = nil) {
+        self.duration = duration
+        self.label = label
     }
 }
 

--- a/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
+++ b/StandLockKit/Sources/StandLockCore/Protocols/LockPresenting.swift
@@ -2,9 +2,12 @@ import Foundation
 
 public protocol LockPresenting: Sendable {
     /// - Parameter escalationTier: Per-schedule enforcement tier (0-3). 0 = base behavior, 3 = maximum friction.
+    /// - Parameter nextIntervalLabel: Label of the work block that follows this break; `nil` for
+    ///   schedules without a labeled interval cycle.
     @MainActor func showOverlay(level: DisciplineLevel, duration: TimeInterval,
                                 exercise: Exercise?, preferences: AppPreferences,
-                                statistics: BreakStatistics, escalationTier: Int)
+                                statistics: BreakStatistics, escalationTier: Int,
+                                nextIntervalLabel: String?)
     @MainActor func dismissOverlay()
     @MainActor var isShowing: Bool { get }
 }

--- a/StandLockKit/Sources/StandLockCore/Protocols/SchedulingEngine.swift
+++ b/StandLockKit/Sources/StandLockCore/Protocols/SchedulingEngine.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol SchedulingEngine: Sendable {
-    func nextBreakTime(for schedule: Schedule, after date: Date) -> Date?
+    func nextBreakTime(for schedule: Schedule, after date: Date, cycleIndex: Int) -> Date?
     func breakDuration(for schedule: Schedule, breakIndex: Int) -> TimeInterval
     func isWithinActiveWindow(_ schedule: Schedule, at date: Date) -> Bool
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -10,9 +10,11 @@ final class MockScheduler: SchedulingEngine, @unchecked Sendable {
     var nextBreakTimeToReturn: Date?
     var nextBreakTimes: [UUID: Date] = [:]
     var breakDurationToReturn: TimeInterval = 300
+    var receivedCycleIndices: [(scheduleID: UUID, index: Int)] = []
 
-    func nextBreakTime(for schedule: Schedule, after date: Date) -> Date? {
-        nextBreakTimes[schedule.id] ?? nextBreakTimeToReturn
+    func nextBreakTime(for schedule: Schedule, after date: Date, cycleIndex: Int) -> Date? {
+        receivedCycleIndices.append((scheduleID: schedule.id, index: cycleIndex))
+        return nextBreakTimes[schedule.id] ?? nextBreakTimeToReturn
     }
     func breakDuration(for schedule: Schedule, breakIndex: Int) -> TimeInterval { breakDurationToReturn }
     func isWithinActiveWindow(_ schedule: Schedule, at date: Date) -> Bool { true }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -33,16 +33,19 @@ final class MockLocker: LockPresenting, @unchecked Sendable {
     var lastDuration: TimeInterval?
     var lastPreferences: AppPreferences?
     var lastEscalationTier: Int?
+    var lastNextIntervalLabel: String?
     var isShowing = false
 
     func showOverlay(level: DisciplineLevel, duration: TimeInterval,
                      exercise: Exercise?, preferences: AppPreferences,
-                     statistics: BreakStatistics, escalationTier: Int) {
+                     statistics: BreakStatistics, escalationTier: Int,
+                     nextIntervalLabel: String?) {
         showOverlayCalled = true
         lastLevel = level
         lastDuration = duration
         lastPreferences = preferences
         lastEscalationTier = escalationTier
+        lastNextIntervalLabel = nextIntervalLabel
         isShowing = true
     }
 
@@ -1596,6 +1599,50 @@ struct BreakCoordinatorTests {
 
         #expect(lastCycleIndex(scheduler, for: scheduleA) == 1)
         #expect(lastCycleIndex(scheduler, for: scheduleB) == 0)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func overlayReceivesNextIntervalLabel() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5, intervalCycle: [
+            IntervalStep(duration: 58 * 60, label: "Sitting"),
+            IntervalStep(duration: 28 * 60, label: "Standing"),
+        ])
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        // During the first break the upcoming work block is the cycle's second entry.
+        #expect(locker.lastNextIntervalLabel == "Standing")
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastNextIntervalLabel == "Sitting")
+
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func overlayLabelNilWithoutCycle() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+        #expect(locker.lastNextIntervalLabel == nil)
+
         coordinator.stop()
     }
 

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -58,6 +58,8 @@ func makeSchedule(
     level: DisciplineLevel = .gentle,
     breakInterval: TimeInterval = 60,
     breakDuration: TimeInterval = 10,
+    intervalCycle: [IntervalStep]? = nil,
+    repetitionRule: RepetitionRule? = nil,
     dailyBreakCap: Int? = nil,
     progressiveEnforcement: Bool = false
 ) -> Schedule {
@@ -67,6 +69,8 @@ func makeSchedule(
         windows: [TimeWindow(startHour: 0, startMinute: 0, endHour: 23, endMinute: 59)],
         breakInterval: breakInterval,
         breakDuration: breakDuration,
+        intervalCycle: intervalCycle,
+        repetitionRule: repetitionRule,
         disciplineLevel: level,
         dailyBreakCap: dailyBreakCap,
         progressiveEnforcement: progressiveEnforcement
@@ -1322,5 +1326,300 @@ struct BreakCoordinatorTests {
 
         coordinator.stop()
         listener.cancel()
+    }
+
+    // MARK: - Cycle Index Tests
+
+    private func lastCycleIndex(_ scheduler: MockScheduler, for schedule: Schedule) -> Int? {
+        scheduler.receivedCycleIndices.last(where: { $0.scheduleID == schedule.id })?.index
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnCompletedBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnSkippedActiveBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.skipActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnEscapedBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.escapeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnIdleCountedBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(idleDuration: 600)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 300)
+        let prefs = AppPreferences(idleDetectionEnabled: true)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        // The armed timer captured its target at start; pushing the mock far out keeps the
+        // idle-counted break from re-firing in a tight loop during the sleep below.
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(!locker.showOverlayCalled)
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnMenuSkipNextBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(60)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule()
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(50))
+
+        coordinator.skipNextBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleAdvancesOnPostDeferralSkip() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(screenSharingActive: true)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(
+            scheduler: scheduler, detector: detector, locker: locker,
+            deferralPollingInterval: 0.1
+        )
+        let schedule = makeSchedule()
+        let prefs = AppPreferences(
+            screenSharingDetectionEnabled: true,
+            screenSharingPostDeferral: .skipBreak
+        )
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(!locker.showOverlayCalled)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        detector.contextToReturn = .clear
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(!locker.showOverlayCalled)
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func sleepWithoutOverlayDoesNotAdvanceCycle() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(60)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule()
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(50))
+
+        coordinator.handleSystemSleep()
+        coordinator.handleSystemWake()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 0)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func sleepWithOverlayAdvancesExactlyOnce() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.isShowing)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.handleSystemSleep()
+        // Sleep alone never reschedules; the wake is what lets the mock observe the index.
+        coordinator.handleSystemWake()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func menuSkipDuringOverlayDoesNotDoubleAdvance() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.isShowing)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.skipNextBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        // The pending id was consumed when the overlay triggered, so the menu skip
+        // must not advance a second time.
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func rolloverResetsCycleAndRearmsTimer() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(breakDuration: 5)
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(lastCycleIndex(scheduler, for: schedule) == 1)
+
+        // A timer armed for the 600 s target is still pending; the rollover must reset the
+        // cycle and re-arm anyway so the new day's first break is computed from index 0.
+        let callsBeforeRollover = scheduler.receivedCycleIndices.count
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        coordinator.refreshDailyRollover(now: tomorrow)
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(scheduler.receivedCycleIndices.count > callsBeforeRollover)
+        #expect(lastCycleIndex(scheduler, for: schedule) == 0)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func cycleIndicesIndependentPerSchedule() async {
+        let scheduler = MockScheduler()
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let scheduleA = makeSchedule(breakDuration: 5)
+        let scheduleB = makeSchedule(breakDuration: 5)
+
+        scheduler.nextBreakTimes[scheduleA.id] = Date().addingTimeInterval(0.05)
+        scheduler.nextBreakTimes[scheduleB.id] = Date().addingTimeInterval(100)
+        coordinator.start(with: [scheduleA, scheduleB], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.showOverlayCalled)
+
+        scheduler.nextBreakTimes[scheduleA.id] = Date().addingTimeInterval(600)
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(100))
+
+        #expect(lastCycleIndex(scheduler, for: scheduleA) == 1)
+        #expect(lastCycleIndex(scheduler, for: scheduleB) == 0)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
+    func repetitionRuleDurationFollowsTracker() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(scheduler: scheduler, detector: detector, locker: locker)
+        let schedule = makeSchedule(
+            repetitionRule: RepetitionRule(shortBreakCount: 1, shortBreakDuration: 300, longBreakDuration: 900)
+        )
+
+        coordinator.start(with: [schedule], preferences: AppPreferences())
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastDuration == 300)
+
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        coordinator.completeActiveBreak()
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(locker.lastDuration == 900)
+
+        coordinator.stop()
     }
 }

--- a/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
+++ b/StandLockKit/Tests/CoordinationTests/CoordinationTests.swift
@@ -1578,6 +1578,38 @@ struct BreakCoordinatorTests {
     }
 
     @Test @MainActor
+    func rolloverDuringDeferralKeepsThePendingBreak() async {
+        let scheduler = MockScheduler()
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(0.05)
+        let detector = MockDetector()
+        detector.contextToReturn = DetectionContext(screenSharingActive: true)
+        let locker = MockLocker()
+
+        let coordinator = BreakCoordinator(
+            scheduler: scheduler, detector: detector, locker: locker,
+            deferralPollingInterval: 0.1
+        )
+        let schedule = makeSchedule(breakDuration: 5)
+        let prefs = AppPreferences(screenSharingDetectionEnabled: true)
+
+        coordinator.start(with: [schedule], preferences: prefs)
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(!locker.showOverlayCalled)
+
+        // The day turns over while the poll is still waiting for the screen share to end.
+        // Re-arming here would cancel the poll and drop the deferred break silently.
+        scheduler.nextBreakTimeToReturn = Date().addingTimeInterval(600)
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        coordinator.refreshDailyRollover(now: tomorrow)
+
+        detector.contextToReturn = .clear
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(locker.showOverlayCalled)
+        coordinator.stop()
+    }
+
+    @Test @MainActor
     func cycleIndicesIndependentPerSchedule() async {
         let scheduler = MockScheduler()
         let detector = MockDetector()

--- a/StandLockKit/Tests/SchedulingTests/SchedulingTests.swift
+++ b/StandLockKit/Tests/SchedulingTests/SchedulingTests.swift
@@ -18,6 +18,7 @@ private func makeSchedule(
     windows: [TimeWindow] = [TimeWindow(startHour: 9, startMinute: 0, endHour: 17, endMinute: 0)],
     breakInterval: TimeInterval = 2400,
     breakDuration: TimeInterval = 600,
+    intervalCycle: [IntervalStep]? = nil,
     repetitionRule: RepetitionRule? = nil,
     disciplineLevel: DisciplineLevel = .gentle,
     dailyBreakCap: Int? = nil
@@ -25,6 +26,7 @@ private func makeSchedule(
     Schedule(
         name: "Test", days: days, windows: windows,
         breakInterval: breakInterval, breakDuration: breakDuration,
+        intervalCycle: intervalCycle,
         repetitionRule: repetitionRule, disciplineLevel: disciplineLevel,
         dailyBreakCap: dailyBreakCap
     )
@@ -78,7 +80,7 @@ struct ScheduleEvaluatorTests {
     @Test func nextBreakTime_simpleInterval() {
         let monday9am = makeDate(day: 12, hour: 9)
         let schedule = makeSchedule(breakInterval: 2400) // 40 min
-        let next = evaluator.nextBreakTime(for: schedule, after: monday9am)
+        let next = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 0)
         #expect(next != nil)
         let diff = next!.timeIntervalSince(monday9am)
         #expect(diff == 2400)
@@ -87,7 +89,7 @@ struct ScheduleEvaluatorTests {
     @Test func nextBreakTime_multipleBreaks() {
         let monday9_40 = makeDate(day: 12, hour: 9, minute: 40)
         let schedule = makeSchedule(breakInterval: 2400)
-        let next = evaluator.nextBreakTime(for: schedule, after: monday9_40)
+        let next = evaluator.nextBreakTime(for: schedule, after: monday9_40, cycleIndex: 0)
         #expect(next != nil)
         let expected = makeDate(day: 12, hour: 10, minute: 20)
         #expect(abs(next!.timeIntervalSince(expected)) < 1)
@@ -96,7 +98,7 @@ struct ScheduleEvaluatorTests {
     @Test func nextBreakTime_endOfWindow() {
         let monday16_50 = makeDate(day: 12, hour: 16, minute: 50)
         let schedule = makeSchedule(breakInterval: 2400) // 40 min would go past 17:00
-        let next = evaluator.nextBreakTime(for: schedule, after: monday16_50)
+        let next = evaluator.nextBreakTime(for: schedule, after: monday16_50, cycleIndex: 0)
         #expect(next != nil)
         // Should be next day's window start + interval
         let expectedBase = makeDate(day: 13, hour: 9, minute: 0) // Tuesday 09:00
@@ -107,7 +109,7 @@ struct ScheduleEvaluatorTests {
     @Test func nextBreakTime_weekendScheduleOnFriday() {
         let friday17 = makeDate(day: 15, hour: 17, minute: 30) // 2026-05-15 Friday, after window
         let schedule = makeSchedule(days: .weekdays)
-        let next = evaluator.nextBreakTime(for: schedule, after: friday17)
+        let next = evaluator.nextBreakTime(for: schedule, after: friday17, cycleIndex: 0)
         #expect(next != nil)
         // Should be Monday's window
         let mondayBase = makeDate(day: 18, hour: 9, minute: 0) // 2026-05-18 Monday
@@ -139,8 +141,53 @@ struct ScheduleEvaluatorTests {
 
     @Test func nextBreakTime_noActiveSchedule() {
         let schedule = makeSchedule(days: .custom([]))
-        let result = evaluator.nextBreakTime(for: schedule, after: Date())
+        let result = evaluator.nextBreakTime(for: schedule, after: Date(), cycleIndex: 0)
         #expect(result == nil)
+    }
+
+    @Test func nextBreakTime_cycleIndexSelectsInterval() {
+        let monday9am = makeDate(day: 11, hour: 9)
+        let schedule = makeSchedule(intervalCycle: [
+            IntervalStep(duration: 58 * 60), IntervalStep(duration: 28 * 60),
+        ])
+        let first = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 0)
+        #expect(first == makeDate(day: 11, hour: 9, minute: 58))
+        let second = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 1)
+        #expect(second == makeDate(day: 11, hour: 9, minute: 28))
+    }
+
+    @Test func nextBreakTime_cycleIndexWraps() {
+        let monday9am = makeDate(day: 11, hour: 9)
+        let schedule = makeSchedule(intervalCycle: [
+            IntervalStep(duration: 58 * 60), IntervalStep(duration: 28 * 60),
+        ])
+        let next = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 2)
+        #expect(next == makeDate(day: 11, hour: 9, minute: 58))
+    }
+
+    @Test func nextBreakTime_nilCycleFallsBackToBreakInterval() {
+        let monday9am = makeDate(day: 11, hour: 9)
+        let schedule = makeSchedule(breakInterval: 2400, intervalCycle: nil)
+        let next = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 5)
+        #expect(next == makeDate(day: 11, hour: 9, minute: 40))
+    }
+
+    @Test func nextBreakTime_emptyCycleFallsBackToBreakInterval() {
+        let monday9am = makeDate(day: 11, hour: 9)
+        let schedule = makeSchedule(breakInterval: 2400, intervalCycle: [])
+        let next = evaluator.nextBreakTime(for: schedule, after: monday9am, cycleIndex: 3)
+        #expect(next == makeDate(day: 11, hour: 9, minute: 40))
+    }
+
+    @Test func nextBreakTime_endOfWindowUsesSelectedInterval() {
+        let monday16_50 = makeDate(day: 11, hour: 16, minute: 50)
+        let schedule = makeSchedule(intervalCycle: [
+            IntervalStep(duration: 58 * 60), IntervalStep(duration: 28 * 60),
+        ])
+        let next = evaluator.nextBreakTime(for: schedule, after: monday16_50, cycleIndex: 1)
+        // 16:50 + 28 min lands past 17:00, so the window-jump path must also
+        // use the selected interval: Tuesday 09:00 + 28 min.
+        #expect(next == makeDate(day: 12, hour: 9, minute: 28))
     }
 
     @Test func breakDuration_noRepetitionRule() {

--- a/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
+++ b/StandLockKit/Tests/StandLockCoreTests/StandLockCoreTests.swift
@@ -60,6 +60,55 @@ struct ScheduleModelTests {
         #expect(decoded.dailyBreakCap == 10)
     }
 
+    @Test func scheduleJsonRoundTripWithIntervalCycle() throws {
+        let schedule = Schedule(
+            name: "Sit/Stand",
+            days: .weekdays,
+            windows: [TimeWindow(startHour: 9, startMinute: 0, endHour: 17, endMinute: 0)],
+            breakInterval: 58 * 60, breakDuration: 120,
+            intervalCycle: [
+                IntervalStep(duration: 58 * 60, label: "Sitting"),
+                IntervalStep(duration: 28 * 60, label: "Standing"),
+            ]
+        )
+        let data = try JSONEncoder().encode(schedule)
+        let decoded = try JSONDecoder().decode(Schedule.self, from: data)
+        #expect(decoded == schedule)
+        #expect(decoded.intervalCycle?.count == 2)
+        #expect(decoded.intervalCycle?[0].duration == TimeInterval(58 * 60))
+        #expect(decoded.intervalCycle?[1].label == "Standing")
+    }
+
+    @Test func scheduleJsonBackwardCompatibilityWithoutIntervalCycle() throws {
+        let original = Schedule(
+            name: "Old Schedule",
+            days: .weekdays,
+            windows: [TimeWindow(startHour: 9, startMinute: 0, endHour: 17, endMinute: 0)],
+            breakInterval: 2400, breakDuration: 600,
+            intervalCycle: [IntervalStep(duration: 2400)]
+        )
+        let data = try JSONEncoder().encode(original)
+        var json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        json.removeValue(forKey: "intervalCycle")
+        let stripped = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(Schedule.self, from: stripped)
+        #expect(decoded.intervalCycle == nil)
+        #expect(decoded.breakInterval == 2400)
+        #expect(decoded.name == "Old Schedule")
+    }
+
+    @Test func intervalStepEncoding() throws {
+        let labeled = IntervalStep(duration: 1680, label: "Standing")
+        let labeledDecoded = try JSONDecoder().decode(IntervalStep.self, from: JSONEncoder().encode(labeled))
+        #expect(labeledDecoded == labeled)
+        #expect(labeledDecoded.label == "Standing")
+
+        let unlabeled = IntervalStep(duration: 3480)
+        let unlabeledDecoded = try JSONDecoder().decode(IntervalStep.self, from: JSONEncoder().encode(unlabeled))
+        #expect(unlabeledDecoded == unlabeled)
+        #expect(unlabeledDecoded.label == nil)
+    }
+
     @Test func repetitionRuleEncoding() throws {
         let rule = RepetitionRule(shortBreakCount: 4, shortBreakDuration: 300, longBreakDuration: 900)
         let data = try JSONEncoder().encode(rule)


### PR DESCRIPTION
## Summary

A schedule can now define a repeating list of work intervals (e.g. 58 min sitting → break → 28 min standing → break → repeat) instead of a single interval, with optional per-interval labels shown on the break screen ("NEXT: STANDING"). Existing single-interval schedules behave exactly as before.

Fixes #30

- **Model:** `Schedule.intervalCycle: [IntervalStep]?` (duration + optional label), decoded with the established `decodeIfPresent` fallback — old persisted data decodes unchanged; `breakInterval` stays required and mirrors the first entry on save
- **Engine:** `SchedulingEngine.nextBreakTime` gains a `cycleIndex` parameter; the evaluator selects `cycle[index % count]`, falling back to `breakInterval` for nil/empty cycles
- **Coordinator:** per-schedule `cycleIndices` counter advances exactly once per concluded break slot; daily rollover resets to index 0 and re-arms a pending timer
- **Form:** the single "Break every" field becomes a 1–6 row list (windows-section +/− pattern) with an optional label per row; schedule list shows `every 58/28m`
- **Break screen:** new `NextIntervalLabel` view under the level pill, nil end to end for unlabeled schedules

### How it works

1. `scheduleNextBreak` passes the schedule's current cycle index to the evaluator, which picks the interval for that slot.
2. The index advances once per concluded slot: overlay trigger (covers complete/skip/escape/interruption), idle-counted break, menu skip of a pending break, post-deferral skip. A `pendingBreakScheduleID` tells the menu-skip path which schedule to advance and is cleared on trigger and on every cancel path, so a slot can never advance twice.
3. At daily rollover the counter resets and `refreshDailyRollover` now re-arms even when a pre-midnight timer is pending, so each day starts from `interval[0]`.
4. At overlay time the coordinator resolves the upcoming interval's label (index already advanced) and threads it through `LockPresenting` → `OverlayWindowController` → `ManuscriptBreakView`.

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Cycle advance rule | Every concluded slot, not only completions | A skipped break must not shift the sit/stand plan; the cycle tracks wall-clock slots |
| Cycle position | Coordinator state, parameter to the engine | `ScheduleEvaluator` stays a stateless value type |
| Backward compat | Keep `breakInterval` required, synced to first entry | Old data decodes; downgraded versions still see a sane single interval |
| `RepetitionRule` | Untouched, independent counter | It varies break duration, not work intervals; coupling them would change existing behavior |

## Test plan

- [x] 24 new tests: Codable round-trip + backward compat, evaluator index selection/wrap/fallback/window-jump, 12 coordinator lifecycle paths, overlay label threading
- [x] Pre-existing `repetitionRule` coordinator coverage gap closed (`repetitionRuleDurationFollowsTracker`)
- [x] Full suite: 179/179 in StandLockKit; app target builds with no new warnings; each phase commit builds independently
- [x] Manual: 58/28 labeled schedule round-trips through the form; overlay shows NEXT label; legacy single-interval schedule unchanged