### PR TITLE
Take the build number from the workflow run instead of by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,26 @@ jobs:
       - name: Extract version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - name: Extract build number from project.yml
+      - name: Determine build number
         run: |
           set -euo pipefail
-          BUILD_NUM=$(sed -n 's/^ *CURRENT_PROJECT_VERSION: *"\{0,1\}\([0-9][0-9]*\)"\{0,1\} *$/\1/p' project.yml | head -1)
-          if [ -z "$BUILD_NUM" ]; then
-            echo "::error::CURRENT_PROJECT_VERSION not found in project.yml"
+          BUILD_NUM="${{ github.run_number }}"
+
+          # Sparkle decides whether an update is newer by comparing this
+          # number, so it must never go backwards or repeat. run_number has
+          # matched the shipped build since v0.2.2 (9) through v0.3.0 (16),
+          # but it restarts if this workflow is renamed or recreated, which
+          # would strand every existing install on the version it has. Refuse
+          # to build rather than publish an update nobody can receive.
+          PREV=$(curl -sL --fail --max-time 30 \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/appcast.xml" \
+            | sed -n 's/.*<sparkle:version>\([0-9][0-9]*\)<.*/\1/p' | head -1) || PREV=""
+
+          if [ -n "$PREV" ] && [ "$BUILD_NUM" -le "$PREV" ]; then
+            echo "::error::build number ${BUILD_NUM} is not greater than the published ${PREV}. Sparkle would ignore this release. If the Release workflow was renamed or recreated, set CURRENT_PROJECT_VERSION explicitly instead of using run_number."
             exit 1
           fi
+          echo "build number ${BUILD_NUM} (previously published: ${PREV:-none})"
           echo "BUILD_NUMBER=${BUILD_NUM}" >> "$GITHUB_ENV"
 
       # ── Signing & Notarization Setup ──

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,9 @@ jobs:
         run: |
           awk '/^## StandLock v'"${VERSION}"'/{found=1} found&&/^## /&&!/^## StandLock v'"${VERSION}"'/{exit} found{print}' \
             CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+          if [ ! -s "$RUNNER_TEMP/release-notes.md" ]; then
+            echo "::warning::CHANGELOG.md has no '## StandLock v${VERSION}' section; falling back to generated notes"
+          fi
 
       - name: Create GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A macOS menu bar app that locks your screen until you stand up.**
 
-[![Version](https://img.shields.io/badge/version-0.3.0-blue)](https://github.com/yagizdo/StandLock/releases)
+[![Version](https://img.shields.io/github/v/release/yagizdo/standlock?label=version&color=blue)](https://github.com/yagizdo/StandLock/releases)
 [![Release](https://github.com/yagizdo/standlock/actions/workflows/release.yml/badge.svg)](https://github.com/yagizdo/standlock/actions/workflows/release.yml)
 [![macOS 13+](https://img.shields.io/badge/macOS-13%2B-brightgreen)](https://github.com/yagizdo/StandLock/releases/latest)
 [![Homebrew](https://img.shields.io/badge/brew-yagizdo%2Ftap%2Fstandlock-orange)](https://github.com/yagizdo/homebrew-tap)

--- a/project.yml
+++ b/project.yml
@@ -14,9 +14,10 @@ settings:
     ENABLE_HARDENED_RUNTIME: YES
     DEVELOPMENT_TEAM: F475N5N7V6
     # Info.plist reads these through $(MARKETING_VERSION) and
-    # $(CURRENT_PROJECT_VERSION). The release workflow overrides
-    # MARKETING_VERSION from the git tag; bump CURRENT_PROJECT_VERSION here
-    # before tagging, because Sparkle compares updates on it.
+    # $(CURRENT_PROJECT_VERSION). Both are placeholders for local builds only:
+    # the release workflow overrides MARKETING_VERSION from the git tag and
+    # CURRENT_PROJECT_VERSION from its run number. Nothing here needs bumping
+    # before a release.
     MARKETING_VERSION: "0.3.0"
     CURRENT_PROJECT_VERSION: "16"
 


### PR DESCRIPTION
## Why

`CURRENT_PROJECT_VERSION` had to be bumped in `project.yml` before every tag. Sparkle compares that number to decide whether an update is newer, so forgetting the bump publishes a release that no existing install is ever offered — silently, with a green run.

## The number was never independent

Build numbers from the published appcasts, against the Release workflow's run number:

| Tag | `sparkle:version` |
|---|---|
| v0.2.2 | 9 |
| v0.2.3 | 10 |
| v0.2.4 | 11 |
| v0.2.5 | 12 |
| v0.2.6 | 13 |
| v0.2.7 | 14 |
| v0.2.8 | 15 |
| v0.3.0 | 16 |

Latest Release workflow `run_number`: **16**. The manual bump has been tracking the run number by hand the whole time. Reading `github.run_number` continues the same sequence — the next release is 17 either way.

## The guard

`run_number` restarts if this workflow is renamed or recreated, which would strand every existing install. So the step reads `sparkle:version` from the currently published appcast and refuses to build unless the new number is strictly greater:

```
build=17 -> passes
build=16 -> fails: not greater than published 16
build=15 -> fails
feed unreachable -> treated as "no previous release", build continues
```

Verified against the live feed (parses `16` correctly) and each branch exercised.

## Also

`project.yml` keeps `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` as local-build placeholders — without them a local `CFBundleVersion` would expand empty. The comment previously said to bump before tagging; it now says the workflow supplies both.