### PR TITLE
Add the Ventura calendar usage key, fix the re-run trap and the concurrency group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Determine build number
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
           BUILD_NUM="${{ github.run_number }}"
@@ -56,10 +57,14 @@ jobs:
           # to build rather than publish an update nobody can receive.
           # Re-running a failed run keeps the same run_number but the release,
           # and its appcast, may already be published -- comparing against it
-          # would compare this build against itself and never pass. A release
-          # that already exists for this tag means exactly that, so skip.
-          if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            echo "release v${VERSION} already exists; this is a re-run, skipping the monotonicity check"
+          # would compare this build against itself and never pass. Skip only
+          # on an actual re-run: run_attempt alone is not enough (the release
+          # may not exist yet), and an existing release alone is not enough
+          # either (release notes drafted before tagging would match on the
+          # first attempt and disarm the guard when it is most needed).
+          echo "build number ${BUILD_NUM}"
+          if [ "${RUN_ATTEMPT}" -gt 1 ] && gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "release v${VERSION} already exists on run attempt ${RUN_ATTEMPT}; skipping the monotonicity check"
           else
             PREV=$(curl -sL --fail --max-time 30 \
               "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/appcast.xml" \
@@ -71,7 +76,6 @@ jobs:
             fi
             echo "previously published build: ${PREV:-none}"
           fi
-          echo "build number ${BUILD_NUM} (previously published: ${PREV:-none})"
           echo "BUILD_NUMBER=${BUILD_NUM}" >> "$GITHUB_ENV"
 
       # ── Signing & Notarization Setup ──

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,11 @@ on:
 permissions:
   contents: write
 
-# Two tags pushed close together would otherwise race in the tap and could
-# leave the cask pinned to the older release.
+# Deliberately keyed on the repository, not the ref: the point is to stop two
+# different tags racing each other in the tap, and a per-ref group would give
+# them separate lanes and no serialisation at all.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 env:
@@ -41,6 +42,8 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Determine build number
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           BUILD_NUM="${{ github.run_number }}"
@@ -51,13 +54,22 @@ jobs:
           # but it restarts if this workflow is renamed or recreated, which
           # would strand every existing install on the version it has. Refuse
           # to build rather than publish an update nobody can receive.
-          PREV=$(curl -sL --fail --max-time 30 \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/appcast.xml" \
-            | sed -n 's/.*<sparkle:version>\([0-9][0-9]*\)<.*/\1/p' | head -1) || PREV=""
+          # Re-running a failed run keeps the same run_number but the release,
+          # and its appcast, may already be published -- comparing against it
+          # would compare this build against itself and never pass. A release
+          # that already exists for this tag means exactly that, so skip.
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "release v${VERSION} already exists; this is a re-run, skipping the monotonicity check"
+          else
+            PREV=$(curl -sL --fail --max-time 30 \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/appcast.xml" \
+              | sed -n 's/.*<sparkle:version>\([0-9][0-9]*\)<.*/\1/p' | head -1) || PREV=""
 
-          if [ -n "$PREV" ] && [ "$BUILD_NUM" -le "$PREV" ]; then
-            echo "::error::build number ${BUILD_NUM} is not greater than the published ${PREV}. Sparkle would ignore this release. If the Release workflow was renamed or recreated, set CURRENT_PROJECT_VERSION explicitly instead of using run_number."
-            exit 1
+            if [ -n "$PREV" ] && [ "$BUILD_NUM" -le "$PREV" ]; then
+              echo "::error::build number ${BUILD_NUM} is not greater than the published ${PREV}, so Sparkle would ignore this release. run_number restarts when the workflow is renamed or recreated; if that happened, pin CURRENT_PROJECT_VERSION in this step instead of using run_number."
+              exit 1
+            fi
+            echo "previously published build: ${PREV:-none}"
           fi
           echo "build number ${BUILD_NUM} (previously published: ${PREV:-none})"
           echo "BUILD_NUMBER=${BUILD_NUM}" >> "$GITHUB_ENV"
@@ -142,7 +154,7 @@ jobs:
             exit 1
           fi
           if [ "$BUILT_BUILD" != "$BUILD_NUMBER" ]; then
-            echo "::error::app reports build ${BUILT_BUILD} but project.yml says ${BUILD_NUMBER}"
+            echo "::error::app reports build ${BUILT_BUILD} but the workflow supplied ${BUILD_NUMBER}"
             exit 1
           fi
           if [ -z "$BUILT_NAME" ]; then

--- a/StandLock/Info.plist
+++ b/StandLock/Info.plist
@@ -22,6 +22,8 @@
 	<string>StandLock uses accessibility to block keyboard and mouse input during breaks in Strict mode.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>StandLock reads your calendar to defer breaks during meetings.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>StandLock reads your calendar to defer breaks during meetings.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 StandLock</string>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
Follow-ups found by reviewing the last two PRs before cutting a release.

## The calendar key is the one that matters

`CalendarDetector.swift:21` falls back to `requestAccess(to: .event)` below macOS 14. TCC terminates a process that calls it without `NSCalendarsUsageDescription`, and `Info.plist` only had the macOS 14 key, `NSCalendarsFullAccessUsageDescription`.

This was unreachable before today: the appcast said `minimumSystemVersion 15.0` and the cask said `>= :sequoia`, so no Ventura or Sonoma user could install or update. Lowering the floor to 13 opens exactly that path. Both keys are present now, with the same string; macOS 14+ keeps using full access.

Verified in a real build — the exported app carries both keys, and the version plumbing still resolves:

```
CFBundleShortVersionString             0.3.1
CFBundleVersion                        17
CFBundleDisplayName                    StandLock
NSCalendarsUsageDescription            present
NSCalendarsFullAccessUsageDescription  present
```

## The guard made re-runs impossible

It read `sparkle:version` from `releases/latest/download/appcast.xml`. If a run fails after `gh release create`, that URL is the appcast the same run just uploaded, and `run_number` does not advance on re-run — so the check compared the build against itself and always failed. That also made the `gh release view ... --clobber` branch unreachable, which existed specifically so a failed run could be re-run.

An existing release for the tag now means the run is a retry, and the check is skipped. First releases and normal releases are unaffected.

## The concurrency group serialised nothing

`group: release-${{ github.ref }}` is `release-refs/tags/v0.3.1` — unique per tag, so two tags ran concurrently, which is the opposite of what the comment claimed. With `git pull --rebase` gone from the tap script, the loser's push is rejected outright. Keyed on the repository now.

## Also

The verification step's error still said the build number came from `project.yml`; it comes from the workflow run.

180 StandLockKit tests pass.