### PR TITLE
fix(overlay): drop fullScreenAuxiliary so breaks cover other apps' Spaces

### DIFF
--- a/StandLock/Views/BreakScreen/BreakOverlayWindow.swift
+++ b/StandLock/Views/BreakScreen/BreakOverlayWindow.swift
@@ -10,7 +10,7 @@ final class BreakOverlayWindow: NSWindow {
             defer: false
         )
         level = .screenSaver
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
         isOpaque = true
         backgroundColor = .white
         hasShadow = false


### PR DESCRIPTION
Fixes #39.

The break overlay never reached the Space of another app in native full-screen. The break fired and the window was created, but it landed on the Desktop Space and stayed invisible until you left full-screen — on a two-display machine, on neither display.

### The change

```diff
-        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
```

4f8fda8 bundled two changes: removing the activation calls, which was necessary and stays untouched here, and adding `.fullScreenAuxiliary`. That flag describes a window accompanying a full-screen window of the *same* application, and it shares a mutually exclusive group with `.fullScreenPrimary` / `.fullScreenNone`, so setting it opts the window into full-screen management — the opposite of what `.canJoinAllSpaces` asks for on a Space-agnostic overlay. This restores the pre-4f8fda8 `collectionBehavior` while keeping that commit's activation fix.

### Verification

Local v0.3.0 builds tested against full-screen Warp on macOS 26 (Darwin 25.3.0, Apple Silicon, two displays, "Displays have separate Spaces" enabled):

| Build | Overlay covers full-screen app |
| --- | --- |
| v0.3.0 as shipped | no |
| this PR (flag removed, level unchanged) | **yes** |
| flag removed **and** level raised to `CGShieldingWindowLevel()` | yes |

I tested the level raise first and it worked, then isolated the two changes — the level makes no difference, so this PR is the one line. `.screenSaver` = 1000 and `CGShieldingWindowLevel()` = 2147483628 on that machine, so the overlay was never being out-stacked; it was not in the Space at all.

Tested in Gentle mode. My builds were unsigned, so they can't hold an Accessibility grant and I could not exercise Strict mode's event tap. Nothing in this change touches `EventTapController`.

No CHANGELOG entry — `chore(release):` commits look like they own that at release time. Happy to add one if you'd rather.

### Caveat, so you can judge the mechanism yourself

A standalone ~40-line AppKit probe using the **shipping** configuration (`[.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]` at `.screenSaver`, `orderFrontRegardless()`, accessory policy) *does* appear correctly over full-screen Warp. Adding `canBecomeKey`/`canBecomeMain` overrides plus a `makeKey()` timer to mirror `OverlayWindowController.forceFocus()` did not break it either.

So the flag alone isn't sufficient to reproduce this outside the app, and I can't give you a complete account of why it breaks things here. The most likely untested difference is that the probe made one window on `NSScreen.main` while `showOverlay` makes one per screen across two displays. Removing the flag is verified to fix the reported bug; the explanation above is my best reading of why, not something I proved.