### PR TITLE
Fix silent failure of Calendar Access grant (missing hardened runtime entitlement)

### DIFF
--- a/StandLock/StandLock.entitlements
+++ b/StandLock/StandLock.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
## Problem

Clicking **Grant** next to *Calendar Access* in Settings → Permissions does nothing on the notarized v0.3.0 build: no macOS permission prompt appears, and StandLock never shows up in **System Settings → Privacy & Security → Calendars** (only the fallback of opening that pane happens, where the app can't be selected because it was never registered).

## Root cause

The release build is signed with the **Hardened Runtime** (`flags=0x10000(runtime)`) but with an **empty entitlements file** (`StandLock/StandLock.entitlements` is `<dict/>`). Under the Hardened Runtime, calendar access requires the resource-access entitlement `com.apple.security.personal-information.calendars`. Without it, `EKEventStore.requestFullAccessToEvents()` is denied by the OS before it ever reaches `tccd`, so no prompt is shown and no TCC entry is created. The `try?` in `PermissionChecker.requestCalendarAccess()` then swallows the error silently.

Verified on macOS 26 (Tahoe) by streaming `log stream --predicate 'subsystem == "com.apple.TCC"'` while clicking Grant: tccd logs requests from other processes but **no `TCCAccessRequest` from StandLock at all**. `tccutil reset Calendar com.yagizdokumaci.standlock` and a full app restart don't help, which rules out a stale TCC state.

Input Monitoring and Accessibility work fine because those TCC services don't require a hardened-runtime entitlement, which is why only Calendar Access is affected.

## Fix

Add `com.apple.security.personal-information.calendars` to `StandLock.entitlements`. The matching usage description (`NSCalendarsFullAccessUsageDescription`) is already present in the Info.plist, so this is the only missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)