### PR TITLE
fix(release): keep entitlements through the app re-sign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,15 @@ jobs:
       - name: Re-sign app and frameworks
         run: scripts/resign-app.sh
 
+      - name: Verify entitlements survived the re-sign
+        run: |
+          set -euo pipefail
+          APP="$RUNNER_TEMP/export/StandLock.app"
+          if ! codesign -d --entitlements - "$APP" | grep -q personal-information.calendars; then
+            echo "::error::calendars entitlement missing after re-sign"
+            exit 1
+          fi
+
       # ── Notarize & Package ──
 
       - name: Notarize app bundle

--- a/scripts/resign-app.sh
+++ b/scripts/resign-app.sh
@@ -14,5 +14,7 @@ codesign --force --timestamp --options runtime \
   --sign "$SIGNING_IDENTITY" "$FW/Versions/Current/Autoupdate"
 codesign --force --timestamp --options runtime \
   --sign "$SIGNING_IDENTITY" "$FW"
+# --force drops the existing entitlements, so pass them again for the app.
 codesign --force --timestamp --options runtime \
+  --entitlements StandLock/StandLock.entitlements \
   --sign "$SIGNING_IDENTITY" "$APP"


### PR DESCRIPTION
`codesign --force` discards the entitlements from the exported app, so the calendar entitlement from #42 never reached the notarized build. This passes the entitlements file again on the final app signature and adds a workflow step that fails if the calendars key is missing after the re-sign.

Verified locally: a binary signed with `--entitlements` loses the key after a plain `codesign --force`, and keeps it when the entitlements file is passed again.
