### PR TITLE
Link CONTRIBUTING from README and add AGENTS.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent instructions
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before changing anything. It covers setup, tests, code rules and pull request expectations. The points below are the ones agents get wrong most often.
+
+- Most logic lives in `StandLockKit`, a plain Swift package. Put new logic there, not in the app target, so it stays testable.
+- Run `swift test --package-path StandLockKit` before you finish. A bug fix needs a regression test that fails before the fix.
+- If the suite dies with `signal code 11` after a model change, run `swift package clean --package-path StandLockKit` and retry.
+- No `print()`, `debugPrint()`, or `NSLog()` in committed code. Do not wrap them in `#if DEBUG`; delete them.
+- One concern per file, named after its primary type. Keep helpers out of `StandLockApp.swift` and `AppDelegate.swift`.
+- Build settings go in `project.yml`, not `StandLock.xcodeproj`. The project file is regenerated from `project.yml` and the folder contents.
+- Do not edit `CHANGELOG.md`. Release notes are written at release time.
+- Do not add dependencies without an issue agreeing to it first.
+- Keep AI out of git metadata: no `Co-Authored-By:` trailers naming an AI tool, no "Generated with" lines in commits or PR descriptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,6 @@ Branch from `main` and keep each PR to one change. Write commit subjects in the 
 
 ## AI tools
 
-Use them if they help. Read and understand every line before you submit it, because you are the one I will be talking to in review. Keep AI out of the git metadata: no "Generated with Claude Code" style lines in commits or PR descriptions, and no `Co-Authored-By:` trailers naming an AI tool. GitHub turns those trailers into contributor credits, and that list is for people. Mentioning in the PR description that you used an AI tool is fine, but you don't have to.
+Use them if they help. Read and understand every line before you submit it, because you are the one I will be talking to in review. Keep AI out of the git metadata: no "Generated with Claude Code" style lines in commits or PR descriptions, and no `Co-Authored-By:` trailers naming an AI tool. GitHub turns those trailers into contributor credits, and that list is for people. Mentioning in the PR description that you used an AI tool is fine, but you don't have to. [AGENTS.md](AGENTS.md) carries the same rules in a form coding agents pick up on their own.
 
 Contributions are licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A macOS menu bar app that forces you to take stand-up breaks. It runs quietly in
 - [macOS Permissions](#macos-permissions)
 - [Building from Source](#building-from-source)
   - [Deployment Target](#deployment-target)
+- [Contributing](#contributing)
 - [License](#license)
 
 ## Why
@@ -147,7 +148,6 @@ You can revoke any permission at any time in **System Settings > Privacy & Secur
 ```bash
 git clone https://github.com/yagizdo/StandLock.git
 cd StandLock
-xcodegen generate   # required after pulling -- regenerates StandLock.xcodeproj from project.yml
 open StandLock.xcodeproj
 ```
 
@@ -165,6 +165,10 @@ The minimum macOS version is declared in four places, and they do not derive fro
 When raising or lowering the deployment target, update all four and run `xcodegen generate` to refresh `StandLock.xcodeproj`. Direct edits to `StandLock.xcodeproj/project.pbxproj` are overwritten on the next regeneration.
 
 The last two are easy to miss because nothing fails when they are wrong: the build succeeds, and users on the excluded versions are simply never offered the app. That is how 0.3.0 shipped telling Sparkle and Homebrew it needed macOS 15 while the binary reported `minos 13.0`.
+
+## Contributing
+
+Bug fix: open a PR. Feature or behaviour change: open an issue first. Setup, tests and PR expectations are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Problem

README never mentioned CONTRIBUTING.md, so people and coding agents reading the repo from the top did not find it. README also told contributors to run `xcodegen generate` after every pull, while CONTRIBUTING says the project file is committed and XcodeGen is not needed.

## Changes

- README: add a Contributing section and a Contents entry pointing at CONTRIBUTING.md.
- README: remove the `xcodegen generate` line from the clone block. The Deployment Target section keeps its `xcodegen generate` instruction, which still applies when `project.yml` changes.
- AGENTS.md: new. Points agents at CONTRIBUTING.md and lists the rules they break most often (tests, no debug prints, one concern per file, `project.yml` over the project file, leave CHANGELOG alone, no AI trailers in git metadata). Every rule is lifted from CONTRIBUTING; nothing new.
- CLAUDE.md: new, one line, `@AGENTS.md`. Claude Code imports AGENTS.md instead of needing a second copy.
- CONTRIBUTING.md: one sentence in the AI tools section referencing AGENTS.md.

## Testing

Docs only. Checked that every relative link target exists and the `#contributing` anchor matches the new header.
